### PR TITLE
feat: componentize savesystem

### DIFF
--- a/Common.csproj
+++ b/Common.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
         <ExcludeGeneratedDebugSymbol>False</ExcludeGeneratedDebugSymbol>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>DiscoAPI</AssemblyName>
         <Description>Modding API for Disco Elysium (separate Runtime-agnostic components only)</Description>
         <Version>0.0.1</Version>

--- a/Common.csproj
+++ b/Common.csproj
@@ -7,7 +7,7 @@
         <Nullable>enable</Nullable>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
         <ExcludeGeneratedDebugSymbol>False</ExcludeGeneratedDebugSymbol>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <AssemblyName>DiscoAPI</AssemblyName>
         <Description>Modding API for Disco Elysium (separate Runtime-agnostic components only)</Description>
         <Version>0.0.1</Version>

--- a/Runtime.csproj
+++ b/Runtime.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ModPath>DiscoAPI</ModPath>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     
     <Import Project="./config.targets" />

--- a/Runtime.csproj
+++ b/Runtime.csproj
@@ -8,7 +8,6 @@
 
     <PropertyGroup>
         <Version>0.0.1</Version>
-        <LangVersion>latest</LangVersion>
         <Nullable>enable</Nullable>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
         <ExcludeGeneratedDebugSymbol>False</ExcludeGeneratedDebugSymbol>

--- a/Runtime.csproj
+++ b/Runtime.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <ModPath>DiscoAPI</ModPath>
-        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
     
     <Import Project="./config.targets" />

--- a/disco.targets
+++ b/disco.targets
@@ -1,4 +1,4 @@
-<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="17.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <ItemDefinitionGroup>
         <ProjectReference>
             <Private>false</Private>
@@ -13,7 +13,7 @@
         <OutputFolder Condition="'$(OutputFolder)' == ''">$(BepInExPlugins)/$(ModPath)</OutputFolder>
         
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <TargetFramework>net6.0-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <UnityEditor2020 Condition="'$(UnityEditor2020)' == ''">$(Unity2020)/Editor/Unity</UnityEditor2020>
     </PropertyGroup>
 

--- a/disco.targets
+++ b/disco.targets
@@ -13,7 +13,7 @@
         <OutputFolder Condition="'$(OutputFolder)' == ''">$(BepInExPlugins)/$(ModPath)</OutputFolder>
         
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-        <TargetFramework>net8.0-windows</TargetFramework>
+        <TargetFramework>net6.0-windows</TargetFramework>
         <UnityEditor2020 Condition="'$(UnityEditor2020)' == ''">$(Unity2020)/Editor/Unity</UnityEditor2020>
     </PropertyGroup>
 

--- a/src/Common/SaveSystem/ModSaveData.cs
+++ b/src/Common/SaveSystem/ModSaveData.cs
@@ -14,7 +14,7 @@ public class ModSaveData
     public ModSaveData(string modGuid)
     {
         this.modGuid = modGuid;
-        this.entries = [];
+        this.entries = new();
     }
 
     public bool KeyExists(string key) => entries.ContainsKey(key);

--- a/src/Common/SaveSystem/ModSaveData.cs
+++ b/src/Common/SaveSystem/ModSaveData.cs
@@ -21,7 +21,7 @@ public class ModSaveData
 
     public int GetInt(string key)
     {
-        if (!entries.TryGetValue(key, out var value))        
+        if (!entries.TryGetValue(key, out var value))
         {
             WarnIfKeyNotExists(key);
             return default;
@@ -31,7 +31,7 @@ public class ModSaveData
 
     public string? GetString(string key)
     {
-        if (!entries.TryGetValue(key, out var value))        
+        if (!entries.TryGetValue(key, out var value))
         {
             WarnIfKeyNotExists(key);
             return default;
@@ -51,7 +51,7 @@ public class ModSaveData
 
     public T? GetObject<T>(string key)
     {
-        if (!entries.TryGetValue(key, out var value))       
+        if (!entries.TryGetValue(key, out var value))
         {
             WarnIfKeyNotExists(key);
             return default;
@@ -65,7 +65,7 @@ public class ModSaveData
         {
             WarnIfKeyNotExists(key);
             return default;
-        };
+        }
         return value.Type == JTokenType.Boolean ? value.Value<bool>() : default;
     }
 
@@ -75,7 +75,8 @@ public class ModSaveData
         {
             WarnIfKeyNotExists(key);
             return default;
-        };
+        }
+        ;
         return value;
     }
 

--- a/src/Runtime/Components/CharacterSheet.cs
+++ b/src/Runtime/Components/CharacterSheet.cs
@@ -2,9 +2,10 @@ using System.Collections.Generic;
 using System.Linq;
 using DiscoAPI.Common.Assets;
 using Voidforge;
-using JsonUtil = Sunshine.JsonUtil;
 using SM = Sunshine.Metric;
 using Il2CppCollection = Il2CppSystem.Collections.Generic;
+using DiscoAPI.Runtime.SaveSystem;
+using Newtonsoft.Json.Linq;
 
 namespace DiscoAPI.Runtime.Components;
 
@@ -13,19 +14,13 @@ public interface IRecalculable
 	void Recalc();
 }
 
-public sealed class SkillContainer
+public sealed class SkillContainer : ISaveSerializable<SkillContainer, ModCharacterSheet>
 {
 	private Dictionary<AssetLocation, SM.Skill> skillMap = new();
 
 	public SM.Skill? GetRawSkill(IAssetRef<Skill> skill) => skillMap.GetValueOrDefault(skill.Location);
 	public SM.Skill MoraleRaw => GetRawSkill(DiscoRunner.globalConfig.MoraleSkill)!;
 	public SM.Skill HealthRaw => GetRawSkill(DiscoRunner.globalConfig.HealthSkill)!;
-
-	public SkillContainer()
-	{
-		DiscoRunner.saveGame.Add(SaveSkillSunshineData);
-		DiscoRunner.loadSavedGame.Add(LoadSkillSunshineData);
-	}
 
 	internal void ReinitializeFromNativeInstance(SM.CharacterSheet sheet)
 	{
@@ -61,54 +56,54 @@ public sealed class SkillContainer
 		sheet.skills = skills;
 	}
 
-	private void SaveSkillSunshineData()
+	public JToken Serialize()
 	{
 		var smSkillsForSerialize = new Il2CppCollection.List<SM.Skill>();
 		var skillModifierStateMap = new Il2CppCollection.Dictionary<SM.SkillType, Il2CppCollection.List<CharacterSheetPersister.ModifierState>>();
-		
+
 		foreach (var modSkill in SkillUtils.Skills)
 		{
 			var smSkill = GetRawSkill(modSkill.Location);
 			if (smSkill == null || SkillUtils.SkillIsVanilla(smSkill.skillType)) continue;
-			
+
 			DiscoRunner.Log.LogInfo("Saving " + modSkill.displayName);
 			skillModifierStateMap.Add(smSkill.skillType, new Il2CppCollection.List<CharacterSheetPersister.ModifierState>());
-			
+
 			foreach (var mod in smSkill.modifiers)
 			{
 				var modState = CharacterSheetPersister.ConvertModifierToModifierState(mod);
 				skillModifierStateMap[smSkill.skillType].Add(modState);
 				smSkill.ClearModifiersForPersistence();
 			}
-			
+
 			smSkillsForSerialize.Add(smSkill);
 		}
 
-		var saveData = DiscoRunner.saveSystem.GetModData("disco");
 		// builtin serializer used here bc it obeys Modifiable serializer attribs
-		var dumbSerializerMods = JsonUtil.Serialize(skillModifierStateMap);
-		saveData.SetString("modifierStateMap", dumbSerializerMods);
-		var dumbSerializerJson = JsonUtil.Serialize(smSkillsForSerialize);
-		saveData.SetString("sunshineSkills", dumbSerializerJson);
+		return new JObject {
+			{ "modifierStateMap", Sunshine.JsonUtil.Serialize(skillModifierStateMap) },
+			{ "sunshineSkills", Sunshine.JsonUtil.Serialize(smSkillsForSerialize) },
+		};
 	}
 
-	private void LoadSkillSunshineData()
+
+	public bool TryDeserialize(JToken token, ModCharacterSheet sheet)
 	{
-		var saveData = DiscoRunner.saveSystem.GetModData("disco");
-		string? modifierStatesJson = saveData.GetString("modifierStateMap");
-		string? serializedSkillsJson = saveData.GetString("sunshineSkills");
+		JObject obj = (JObject)token;
+		string? modifierStatesJson = obj.GetValue("modifierStateMap")?.Value<string>();
+		string? serializedSkillsJson = obj.GetValue("sunshineSkills")?.Value<string>();
 		if (modifierStatesJson == null || serializedSkillsJson == null)
 		{
 			DiscoRunner.Log.LogWarning("failed to load mod skill data for this savegame. aborting!");
-			return;
+			return false;
 		}
 
-		var modStates = JsonUtil.Deserialize<Il2CppCollection.Dictionary
+		var modStates = Sunshine.JsonUtil.Deserialize<Il2CppCollection.Dictionary
 				<SM.SkillType, Il2CppCollection.List<CharacterSheetPersister.ModifierState>>>
 				(modifierStatesJson);
-		var smSkills = JsonUtil.Deserialize<Il2CppCollection.List<SM.Skill>>(serializedSkillsJson);
+		var smSkills = Sunshine.JsonUtil.Deserialize<Il2CppCollection.List<SM.Skill>>(serializedSkillsJson);
 
-		var characterSheet = SingletonComponent<World>.Singleton.you;
+		var characterSheet = sheet.EntityBase;
 
 		foreach (var smSkill in smSkills)
 		{
@@ -119,7 +114,7 @@ public sealed class SkillContainer
 				var builtMod = BuildModifierFromState(characterSheet, modState);
 				if (builtMod != null) smSkill.modifiers.Add(builtMod);
 			}
-			
+
 			// repopulate into mod skills
 			var modSkill = SkillUtils.Lookup(smSkill.skillType);
 			if (modSkill != null)
@@ -127,8 +122,9 @@ public sealed class SkillContainer
 				skillMap[modSkill.Location] = smSkill;
 			}
 		}
-		
+
 		RepopulateNativeInstanceLists(characterSheet);
+		return true;
 	}
 
 	private static SM.Modifier? BuildModifierFromState(SM.CharacterSheet sheet, CharacterSheetPersister.ModifierState modState)
@@ -142,10 +138,10 @@ public sealed class SkillContainer
 			if (effect != null)
 			{
 				modifier = new SM.Modifier(
-					modState.type, 
-					effect.parameter, 
-					(Il2CppSystem.Func<string>)effect.EffectName(), 
-					modifierCause, 
+					modState.type,
+					effect.parameter,
+					(Il2CppSystem.Func<string>)effect.EffectName(),
+					modifierCause,
 					modState.skillType);
 			}
 		}
@@ -179,7 +175,8 @@ public sealed class SkillContainer
 	}
 }
 
-public class ModCharacterSheet : ModEntity<ModCharacterSheet, SM.CharacterSheet>, IRecalculable
+public class ModCharacterSheet : ModEntity<ModCharacterSheet, SM.CharacterSheet>,
+	IRecalculable
 {
 	public static ModEntityRegistry<ModCharacterSheet, SM.CharacterSheet> Registry { get; }
 		= new(new PersistentEntityMap<ModCharacterSheet, SM.CharacterSheet>(s => new(s)));

--- a/src/Runtime/Components/DataModel.cs
+++ b/src/Runtime/Components/DataModel.cs
@@ -2,18 +2,21 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using BepInEx.Logging;
 using DiscoAPI.Common.Assets;
+using DiscoAPI.Runtime.SaveSystem;
 using Il2CppInterop.Runtime.InteropTypes;
+using Newtonsoft.Json.Linq;
 
 namespace DiscoAPI.Runtime.Components;
 
-public sealed class ComponentKey<D, T, P>
+public abstract class ComponentKey<T, P>
 	where T : ModEntity<T, P>
 	where P : Il2CppObjectBase
-	where D : notnull
 {
+	public Type DataType => Location.type.type;
 	public AssetLocation Location { get; }
 	public ModEntityRegistry<T, P> Registry { get; }
 
@@ -22,6 +25,14 @@ public sealed class ComponentKey<D, T, P>
 		Registry = registry;
 		Location = location;
 	}
+}
+
+public sealed class ComponentKey<D, T, P> : ComponentKey<T, P>
+	where T : ModEntity<T, P>
+	where P : Il2CppObjectBase
+	where D : notnull
+{
+	public ComponentKey(ModEntityRegistry<T, P> registry, AssetLocation location) : base(registry, location) { }
 
 	public D? Of(T t) => t.Get<D>(this);
 	public D? Of(P p) => Of(Registry.EntityOf(p));
@@ -29,12 +40,16 @@ public sealed class ComponentKey<D, T, P>
 	public bool TryOf(P p, [NotNullWhen(true)] out D? value) => TryOf(Registry.EntityOf(p), out value);
 }
 
-public interface IEntityProvider<T, P> where T : ModEntity<T, P> where P : Il2CppObjectBase
+public interface IEntityProvider<T, P>
+	where T : ModEntity<T, P>
+	where P : Il2CppObjectBase
 {
 	T Map(P p);
 }
 
-public class CWTEntityMap<T, P> : IEntityProvider<T, P> where T : ModEntity<T, P> where P : Il2CppObjectBase
+public class CWTEntityMap<T, P> : IEntityProvider<T, P>
+	where T : ModEntity<T, P>
+	where P : Il2CppObjectBase
 {
 	// NB: A CWT is like a dictionary which doesn't store or keepalive keys or values.
 	//     Any given P always maps to the same T.
@@ -53,7 +68,9 @@ public class CWTEntityMap<T, P> : IEntityProvider<T, P> where T : ModEntity<T, P
 	}
 }
 
-public class PersistentEntityMap<T, P> : IEntityProvider<T, P> where T : ModEntity<T, P> where P : UnityEngine.Object
+public class PersistentEntityMap<T, P> : IEntityProvider<T, P>
+	where T : ModEntity<T, P>
+	where P : UnityEngine.Object
 {
 	private ConcurrentDictionary<P, T> entities = new();
 	private Func<P, T> initializer;
@@ -76,6 +93,7 @@ public class PersistentEntityMap<T, P> : IEntityProvider<T, P> where T : ModEnti
 
 public class ModEntityRegistry<T, P> where T : notnull, ModEntity<T, P> where P : Il2CppObjectBase
 {
+	private Dictionary<(string, string), ComponentKey<T, P>> registered = new();
 	internal IEntityProvider<T, P> entities;
 
 	public ModEntityRegistry(IEntityProvider<T, P> entities)
@@ -85,34 +103,53 @@ public class ModEntityRegistry<T, P> where T : notnull, ModEntity<T, P> where P 
 
 	public ComponentKey<D, T, P> Register<D>(string source, string id) where D : notnull
 	{
-		ComponentKey<D, T, P> key = new(this, new(new AssetType(typeof(ComponentKey<D, T, P>)), source, id));
-		// TBD: anything here?
+		AssetLocation asset = new(new AssetType(typeof(D)), source, id);
+		ComponentKey<D, T, P> key = new(this, asset);
+
+		if (!registered.TryAdd((source, id), key)) throw new Exception($"duplicate component key {asset}");
 		return key;
 	}
 
+	public IEnumerable<ComponentKey<T, P>> Keys => registered.Values;
+
 	public T EntityOf(P p) => entities.Map(p);
+
+	public bool TryDeserialize(JToken? token, P p)
+	{
+		if (token == null || !(token is JObject obj)) return false;
+		T cx = EntityOf(p);
+
+		foreach (var key in Keys)
+		{
+			if (!(obj.GetValue(key.ToString()) is JToken token2)) continue;
+			object datum = Activator.CreateInstance(key.DataType)!;
+			if (ModSaveSystem.TryDeserializeUntyped(key.DataType, token2, cx, datum)) cx.AddUntyped(key, datum);
+		}
+
+		return true;
+	}
 }
 
 public interface IComponentStore
 {
-	bool Contains(object key);
-	object? Get(object key);
-	bool TryGet(object key, [NotNullWhen(true)] out object? component);
-	void Add(object key, object component);
-	bool Remove(object key);
-	IEnumerable<object> Values { get; }
+	bool Contains(AssetLocation key);
+	object? Get(AssetLocation key);
+	bool TryGet(AssetLocation key, [NotNullWhen(true)] out object? component);
+	void Add(AssetLocation key, object component);
+	bool Remove(AssetLocation key);
+	IEnumerable<(AssetLocation, object)> Entries { get; }
 }
 
 public class DictComponentStore : IComponentStore
 {
-	private Dictionary<object, object> components = new();
-	public IEnumerable<object> Values => components.Values;
+	private Dictionary<AssetLocation, object> components = new();
+	public IEnumerable<(AssetLocation, object)> Entries => components.Select(kv => (kv.Key, kv.Value));
 
-	public bool Contains(object key) => components.ContainsKey(key);
-	public object? Get(object key) => components.GetValueOrDefault(key);
-	public bool TryGet(object key, [NotNullWhen(true)] out object? component) => components.TryGetValue(key, out component);
-	public void Add(object key, object component) => components.Add(key, component);
-	public bool Remove(object key) => components.Remove(key);
+	public bool Contains(AssetLocation key) => components.ContainsKey(key);
+	public object? Get(AssetLocation key) => components.GetValueOrDefault(key);
+	public bool TryGet(AssetLocation key, [NotNullWhen(true)] out object? component) => components.TryGetValue(key, out component);
+	public void Add(AssetLocation key, object component) => components.Add(key, component);
+	public bool Remove(AssetLocation key) => components.Remove(key);
 }
 
 public abstract class ModEntity<T, P>
@@ -139,34 +176,51 @@ public abstract class ModEntity<T, P>
 
 	public static implicit operator P(ModEntity<T, P> entity) => entity.EntityBase;
 
-	public IEnumerable<object> ComponentData => Components.Values;
+	public IEnumerable<(AssetLocation, object)> ComponentData => Components.Entries;
 
-	public D? Get<D>(ComponentKey<D, T, P> key) where D : notnull => (D?)Components.Get(key);
-	public bool Contains<D>(ComponentKey<D, T, P> key) where D : notnull => Components.Contains(key);
+	public object? Get(ComponentKey<T, P> key) => Components.Get(key.Location);
+	public D? Get<D>(ComponentKey<D, T, P> key) where D : notnull => (D?)Components.Get(key.Location);
+	public bool Contains<D>(ComponentKey<D, T, P> key) where D : notnull => Components.Contains(key.Location);
 	public bool Remove<D>(ComponentKey<D, T, P> key) where D : notnull
 	{
 		ComponentLifecycleTracker.ComponentRemoved(this, key);
-		return Components.Remove(key);
+		return Components.Remove(key.Location);
+	}
+
+	public void AddUntyped(ComponentKey<T, P> key, object component)
+	{
+		ComponentLifecycleTracker.ComponentAdded(this, component);
+		Components.Add(key.Location, component);
 	}
 
 	public void Add<D>(ComponentKey<D, T, P> key, D component) where D : notnull
 	{
 		ComponentLifecycleTracker.ComponentAdded(this, component);
-		Components.Add(key, component);
+		Components.Add(key.Location, component);
 	}
 	public bool TryGet<D>(ComponentKey<D, T, P> key, [NotNullWhen(true)] out D? component) where D : notnull
 	{
-		bool success = Components.TryGet(key, out object? a);
+		bool success = Components.TryGet(key.Location, out object? a);
 		component = (D?)a;
 		return success;
 	}
 	public D GetOrCreate<D>(ComponentKey<D, T, P> key, Func<T, D> factory) where D : notnull
 	{
-		if (Components.TryGet(key, out object? component)) return (D)component;
+		if (Components.TryGet(key.Location, out object? component)) return (D)component;
 		D d = factory((T)this);
 		Add(key, d);
 		return d;
 	}
+
+	public JToken Serialize()
+	{
+		JObject obj = new();
+
+		foreach ((AssetLocation loc, object datum) in ComponentData)
+			if (datum is ISaveSerializable ser) obj.Add(loc.ToString(), ser.Serialize());
+		return obj;
+	}
+
 }
 
 public static class ComponentLifecycleTracker
@@ -196,19 +250,17 @@ public static class ComponentLifecycleTracker
 		log.LogDebug($"DESPAWN {Entity(entity)}");
 	}
 
-	public static void ComponentAdded<D, T, P>(ModEntity<T, P> entity, D d)
+	public static void ComponentAdded<T, P>(ModEntity<T, P> entity, object d)
 		where T : ModEntity<T, P>
 		where P : Il2CppObjectBase
-		where D : notnull
 	{
 		if (!DiscoAPISettings.ComponentLifecycleTracking) return;
 		log.LogDebug($"ADD component {d} ON {Entity(entity)}");
 	}
 
-	public static void ComponentRemoved<D, T, P>(ModEntity<T, P> entity, ComponentKey<D, T, P> key)
+	public static void ComponentRemoved<T, P>(ModEntity<T, P> entity, ComponentKey<T, P> key)
 		where T : ModEntity<T, P>
 		where P : Il2CppObjectBase
-		where D : notnull
 	{
 		if (!DiscoAPISettings.ComponentLifecycleTracking) return;
 		log.LogDebug($"REMOVE component {entity.Get(key)} ON {Entity(entity)}");

--- a/src/Runtime/Disco/Runner.cs
+++ b/src/Runtime/Disco/Runner.cs
@@ -2,7 +2,6 @@ using System;
 using BepInEx.Logging;
 using BepInEx.Unity.IL2CPP;
 using DiscoAPI.Runtime.Components;
-using DiscoAPI.Runtime.Patches;
 using DiscoAPI.Runtime.SaveSystem;
 using HarmonyLib;
 
@@ -26,8 +25,8 @@ public static class DiscoRunner
     internal static DiscoHook<Action> sceneLoad = new("scene-load");
     internal static DiscoHook<Action> dialogueLoad = new("dialogue-load");
     internal static DiscoHook<Action> preDialogueLoad = new("pre-dialogue-load");
-    internal static DiscoHook<Action> saveGame = new("save-game");
-    internal static DiscoHook<Action> loadSavedGame = new("load-saved-game");
+    internal static DiscoHook<Action<ModSaveSystem>> saveGame = new("save-game");
+    internal static DiscoHook<Action<ModSaveSystem>> loadSavedGame = new("load-saved-game");
 
     public static Harmony Harmony { get; } = new Harmony(DiscoAPIPlugin.GUID);
 

--- a/src/Runtime/Disco/Source.cs
+++ b/src/Runtime/Disco/Source.cs
@@ -38,8 +38,16 @@ public class DiscoSource : IMutableAssets
     public ConfigFile? ConfigFile => cfg.configFile;
 
     public delegate void ModSaveDelegate(ModSaveData saveData);
-    public event ModSaveDelegate OnGameSave;
-    public event ModSaveDelegate OnGameLoad;
+    public event ModSaveDelegate OnGameSave
+    {
+        add => DiscoHooks.OnSaveGame += sys => value(sys.GetModData(this.Guid));
+        remove => DiscoHooks.OnSaveGame -= sys => value(sys.GetModData(this.Guid));
+    }
+    public event ModSaveDelegate OnGameLoad
+    {
+        add => DiscoHooks.OnLoadSavedGame += sys => value(sys.GetModData(this.Guid));
+        remove => DiscoHooks.OnLoadSavedGame -= sys => value(sys.GetModData(this.Guid));
+    }
 
     public DiscoManager Manager { get; }
     IDiscoManager IDiscoSource.Manager => Manager;
@@ -56,7 +64,7 @@ public class DiscoSource : IMutableAssets
 
         this.cfg = cfg;
         Router = cfg.router != null ? new MemoizedAssetRouter(cfg.router) : new EmptyAssetRouter();
-        
+
         if (isVanilla) tables = Enumerable.ToDictionary(manager.Assets.GetDefaultVanillaTables(this), value => value.AssetType);
         else tables = new();
     }

--- a/src/Runtime/GlobalConfig.cs
+++ b/src/Runtime/GlobalConfig.cs
@@ -16,7 +16,7 @@ public record struct SkillPanelConfig(
 	string? portraitOverride = null
 )
 {
-	public SkillLabelSettings? labelSettings;
+	public SkillLabelSettings? labelSettings = default;
 	public Flags flags = skill != null ? Flags.None : Flags.Inert;
 
 	[Flags]

--- a/src/Runtime/Hooks.cs
+++ b/src/Runtime/Hooks.cs
@@ -28,7 +28,7 @@ internal class DelegateConsumer<D> where D : Delegate
 		if (dlg.ReturnType != typeof(void))
 			throw new ArgumentException($"cannot create a hook from a delegate with a return type (it returns {dlg.ReturnType}).");
 
-		Type[] parameters = dlg.GetParameters().Select(param => param.GetType()).ToArray();
+		Type[] parameters = dlg.GetParameters().Select(param => param.ParameterType).ToArray();
 		DynamicMethod method = new(
 			"InvokeDelegates",
 			null,
@@ -86,7 +86,7 @@ internal class DelegateConsumer<D> where D : Delegate
 
 	private static DynamicMethod method = GenerateInvocationMethod();
 
-	public D Invocation => (D)method.CreateDelegate(typeof(D), this);
+	public static D NewInvocation(DiscoHook<D> hook) => method.CreateDelegate<D>(new DelegateConsumer<D>(hook));
 }
 
 public class DiscoHook<D> where D : Delegate
@@ -94,7 +94,7 @@ public class DiscoHook<D> where D : Delegate
 	internal readonly List<D> actions = new();
 
 	public string id;
-	public D Invoke => new DelegateConsumer<D>(this).Invocation;
+	public D Invoke => DelegateConsumer<D>.NewInvocation(this);
 
 	public DiscoHook(string id)
 	{

--- a/src/Runtime/Hooks.cs
+++ b/src/Runtime/Hooks.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
+using DiscoAPI.Runtime.SaveSystem;
 using HarmonyLib;
 
 namespace DiscoAPI.Runtime;
@@ -136,14 +137,14 @@ public static class DiscoHooks
 		add => DiscoRunner.dialogueLoad.Add(value);
 		remove => DiscoRunner.dialogueLoad.Remove(value);
 	}
-	
-	public static event Action OnSaveGame
+
+	public static event Action<ModSaveSystem> OnSaveGame
 	{
 		add => DiscoRunner.saveGame.Add(value);
 		remove => DiscoRunner.saveGame.Remove(value);
 	}
-	
-	public static event Action OnLoadSavedGame
+
+	public static event Action<ModSaveSystem> OnLoadSavedGame
 	{
 		add => DiscoRunner.loadSavedGame.Add(value);
 		remove => DiscoRunner.loadSavedGame.Remove(value);

--- a/src/Runtime/InherentProvider.cs
+++ b/src/Runtime/InherentProvider.cs
@@ -1,6 +1,8 @@
 using DiscoAPI.Common.Assets;
 using DiscoAPI.Common.Dialogue;
 using DiscoAPI.Runtime.Assets;
+using DiscoAPI.Runtime.Components;
+using Newtonsoft.Json.Linq;
 using UnityEngine;
 using PC = PixelCrushers.DialogueSystem;
 using SM = Sunshine.Metric;
@@ -38,6 +40,18 @@ public static class InherentProvider
 		assets.Register(new PCProxyArena<Task, PC.Conversation>(convos.Raw, (conv) => conv.FieldExists("display_condition_main")), false);
 
 		DiscoHooks.OnDialogueLoad += OnDialogueBundleLoad;
+		DiscoHooks.OnSaveGame += save =>
+		{
+			var mod = save.GetModData(source.Guid);
+			mod.SetObject("you", DiscoRunner.world!.You.Serialize());
+			mod.SetObject("world", DiscoRunner.world.Serialize());
+		};
+		DiscoHooks.OnLoadSavedGame += save =>
+		{
+			var mod = save.GetModData(source.Guid);
+			ModCharacterSheet.Registry.TryDeserialize(mod.GetObject<JToken>("you"), global::World.singleton.you);
+			ModWorld.Registry.TryDeserialize(mod.GetObject<JToken>("world"), global::World.singleton);
+		};
 	}
 
 

--- a/src/Runtime/Patches/Character.cs
+++ b/src/Runtime/Patches/Character.cs
@@ -16,10 +16,10 @@ public static class CharacterPatches
 	[HarmonyPostfix]
 	private static void OnRecalc(SM.CharacterSheet __instance)
 	{
-		foreach (object datum in ModCharacterSheet.Of(__instance).ComponentData)
+		foreach ((_, object datum) in ModCharacterSheet.Of(__instance).ComponentData)
 			if (datum is IRecalculable) ((IRecalculable)datum).Recalc();
 	}
-	
+
 	// debugging function for skill value mismatch
 	[HarmonyPatch(typeof(SM.Modifiable), nameof(SM.Modifiable.Recalc))]
 	[HarmonyPostfix]
@@ -44,7 +44,7 @@ public static class CharacterPatches
 		{
 			sb.Append($"Recalcing ability {maybeAbility.abilityType.ToString()}\n");
 		}
-		
+
 		for (int i = 0; i < __instance.modifiers.Count; i++)
 		{
 			var mod = __instance.modifiers[i];
@@ -54,8 +54,8 @@ public static class CharacterPatches
 		sb.Append($"RECALC RESULTS -> CalculatedAbility:{__instance.calculatedAbility} Value:{__instance.value} Modifiers:{__instance.modifiers.Count}\n\n");
 		DiscoRunner.Log.LogInfo(sb.ToString());
 	}
-	
-    [HarmonyPatch(typeof(ThoughtAlterant), nameof(ThoughtAlterant.PassiveSuccess))]
+
+	[HarmonyPatch(typeof(ThoughtAlterant), nameof(ThoughtAlterant.PassiveSuccess))]
 	[HarmonyPrefix]
 	private static bool OnPassiveSuccess(ref bool __result, PC.DialogueEntry entry)
 	{

--- a/src/Runtime/Patches/Persistence.cs
+++ b/src/Runtime/Patches/Persistence.cs
@@ -1,4 +1,3 @@
-using DiscoAPI.Runtime.SaveSystem;
 using HarmonyLib;
 using Il2CppSystem;
 

--- a/src/Runtime/SaveSystem/ModSaveSystem.cs
+++ b/src/Runtime/SaveSystem/ModSaveSystem.cs
@@ -1,81 +1,149 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using DiscoAPI.Common.SaveSystem;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using File = System.IO.File;
-using Path = Il2CppSystem.IO.Path;
 
 namespace DiscoAPI.Runtime.SaveSystem;
 
+public interface ISaveSerializable
+{
+    JToken Serialize();
+}
+
+public interface ISaveSerializable<T, in C> : ISaveSerializable where T : ISaveSerializable<T, C>
+{
+    bool TryDeserialize(JToken token, C context);
+}
+public interface ISaveSerializable<T> : ISaveSerializable<T, object?> where T : ISaveSerializable<T>
+{
+    bool TryDeserialize(JToken token);
+    bool ISaveSerializable<T, object?>.TryDeserialize(JToken token, object? context)
+    {
+        return TryDeserialize(token);
+    }
+}
+
+public enum SaveLoadState
+{
+    Saving,
+    Loading,
+    Neither,
+}
+
 public class ModSaveSystem
 {
-    public Dictionary<string, ModSaveData>? modSaveDatas;
-    private Location _saveDataLocation;
+    public readonly object saveLock = new();
+    public Dictionary<string, ModSaveData> modSaveDatas = new();
+    private SaveLoadState state = SaveLoadState.Neither;
+
+    public static MethodInfo? FindDeserializer(Type target, Type? context)
+    {
+        Type iface = typeof(ISaveSerializable<,>).MakeGenericType(target, context ?? typeof(object));
+        if (!target.IsAssignableTo(iface)) return null;
+
+        return iface?.GetMethod("TryDeserialize", BindingFlags.Static | BindingFlags.Public | BindingFlags.DeclaredOnly);
+    }
+
+    public static bool TryDeserializeUntyped(Type type, JToken token, object? context, object result)
+    {
+        if (FindDeserializer(type, context?.GetType()) is MethodInfo method)
+        {
+            return (bool)method.Invoke(result, new object?[] { token, context })!;
+        }
+        else
+        {
+            return false;
+        }
+    }
 
     public ModSaveData GetModData(string modGuid)
     {
-        if (modSaveDatas == null)
-        {
+        if (state == SaveLoadState.Neither)
             throw new InvalidOperationException(
                 "ModSaveSystem: Retrieval of mod data called outside of save/load hook!");
-        }
 
-        if (modSaveDatas.TryGetValue(modGuid, out var data)) return data;
-        
+
+        if (state != SaveLoadState.Saving && modSaveDatas.TryGetValue(modGuid, out var data)) return data;
+
+        // if saving, return a reference to blank data, since we want to completely overwrite.
         var newData = new ModSaveData(modGuid);
-        modSaveDatas.Add(modGuid, newData);
+        modSaveDatas[modGuid] = newData;
         return newData;
     }
 
+    public string GetPath(string filename) => System.IO.Path.Join(BepInEx.Paths.GameRootPath, "SaveGames", filename + ".json");
+
     public void TriggerSaveEvent(string discoFilename)
     {
-        modSaveDatas = new();
-        _saveDataLocation = DiscoRunner.SourceFromPlugin(DiscoAPIPlugin.Instance).Location.Get($"SaveGames/{discoFilename}.json");
-        foreach (var modSources in DiscoRunner.manager.linearSources)
+        bool taken = false;
+        try
         {
-            var newData = new ModSaveData(modSources.Guid);
-            modSaveDatas.Add(modSources.Guid, newData);
+            Monitor.Enter(saveLock, ref taken);
+            state = SaveLoadState.Saving;
+            DiscoRunner.saveGame.Invoke(this);
+            Task.Run(async () =>
+            {
+                try
+                {
+                    await WriteSaveData(GetPath(discoFilename));
+                    state = SaveLoadState.Neither;
+                }
+                finally
+                {
+                    if (taken) Monitor.Exit(saveLock);
+                    taken = false;
+
+                }
+                GC.Collect();
+            });
         }
-        DiscoRunner.saveGame.Invoke();
-        Task.Run(WriteSaveData);
+        finally
+        {
+            if (taken) Monitor.Exit(saveLock);
+            taken = false;
+        }
     }
 
     public void TriggerLoadEvent(string discoFilename)
     {
-        modSaveDatas = new();
-        _saveDataLocation = DiscoRunner.SourceFromPlugin(DiscoAPIPlugin.Instance).Location.Get($"SaveGames/{discoFilename}.json");
-        modSaveDatas = LoadSaveData();
-        DiscoRunner.loadSavedGame.Invoke();
-        
-        modSaveDatas = null;
+        lock (saveLock)
+        {
+
+            state = SaveLoadState.Loading;
+            modSaveDatas = LoadSaveData(GetPath(discoFilename));
+            DiscoRunner.loadSavedGame.Invoke(this);
+            state = SaveLoadState.Neither;
+        }
         GC.Collect();
     }
 
-    private Dictionary<string, ModSaveData> LoadSaveData()
+    private Dictionary<string, ModSaveData> LoadSaveData(string path)
     {
-        if (File.Exists(_saveDataLocation))
+        if (File.Exists(path))
         {
-            var saveText = File.ReadAllText(_saveDataLocation!);
+            var saveText = File.ReadAllText(path!);
             var converted = JsonConvert.DeserializeObject<Dictionary<string, ModSaveData>>(saveText);
             if (converted == null)
             {
-                DiscoRunner.Log.LogError($"ModSaveSystem : Failed to deserialize valid data from {_saveDataLocation.path}");
+                DiscoRunner.Log.LogError($"ModSaveSystem : Failed to deserialize valid data from {path}");
             }
         }
 
         return new();
     }
 
-    private async Task WriteSaveData()
+    private async Task WriteSaveData(string path)
     {
         DiscoRunner.Log.LogInfo("Writing save data to disk...");
-        Directory.CreateDirectory(Path.GetDirectoryName(_saveDataLocation));
-        var json = JsonConvert.SerializeObject(modSaveDatas, Formatting.Indented, 
-            new JsonSerializerSettings() {ReferenceLoopHandling = ReferenceLoopHandling.Ignore});
-        await File.WriteAllTextAsync(_saveDataLocation!, json);
-        modSaveDatas = null;
-        GC.Collect();
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var json = JsonConvert.SerializeObject(modSaveDatas, Formatting.Indented,
+            new JsonSerializerSettings() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore });
+        await File.WriteAllTextAsync(path!, json);
     }
 }


### PR DESCRIPTION
- ***NB: DO NOT MERGE*** i'm having some troubles with bepinex so this is all untested. i'm also getting lost in the .NET 6 vs. .NET 8 sauce so i need to figure that out.
- use components for savesystem. little bit of reflection trickery but nothing egregious.
- misc relevant improvements to components.
- add a lock to saving to ensure we're thread safe.
- change how savesystem handles saving new/forgotten entires:
  - if a mod entry is requested for saving, create an empty one so no vestigial fields get carried around
  - if an entry for a given mod is never requested though, serialize it verbatim so mods that are unloaded/reloaded stay (probably) valid.