### PR TITLE
fix: prevent a conflict between Newtonsoft.Json DLLs

### DIFF
--- a/Preload.csproj
+++ b/Preload.csproj
@@ -32,13 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <Reference Include="$(BepInExCore)/BepInEx.Core.dll" Private="false"/>
         <Reference Include="$(BepInExCore)/BepInEx.Preloader.Core.dll" Private="false"/>
-        <Reference Include="$(BepInExCore)/BepInEx.Unity.IL2CPP.dll" Private="false"/>
-        <Reference Include="$(BepInExCore)/Mono.Cecil.dll" Private="false"/>
-        <Reference Include="$(BepInExCore)/Mono.Cecil.Mdb.dll" Private="false"/>
-        <Reference Include="$(BepInExCore)/Mono.Cecil.Pdb.dll" Private="false"/>
-        <Reference Include="$(BepInExCore)/Mono.Cecil.Rocks.dll" Private="false"/>
     </ItemGroup>
 
     <Target Name="CopyAssembliesToMods" AfterTargets="Build" Condition="Exists('$(TargetDir)$(TargetName).dll')">

--- a/Preload.csproj
+++ b/Preload.csproj
@@ -1,0 +1,56 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <ModPath>DiscoAPI.Preload</ModPath>
+    </PropertyGroup>
+    
+    <Import Project="./config.targets" />
+
+    <PropertyGroup>
+        <Version>0.0.1</Version>
+        <Nullable>enable</Nullable>
+        <LangVersion>latest</LangVersion>
+        <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+        <ExcludeGeneratedDebugSymbol>False</ExcludeGeneratedDebugSymbol>
+        <AssemblyName>DiscoAPI.Preload</AssemblyName>
+        <Description>Modding API for Disco Elysium (preload patch only)</Description>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <RootNamespace>DiscoAPI.Preload</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>        
+        <Compile Include="src/Preload/**/*.cs" />
+    </ItemGroup>
+
+    <PropertyGroup>
+        <BepInExCore>$(DiscoElysium)/BepInEx/core</BepInExCore>
+        <BepInExPatchers>$(DiscoElysium)/BepInEx/patchers</BepInExPatchers>
+        <OutputFolder Condition="'$(OutputFolder)' == ''">$(BepInExPatchers)/$(ModPath)</OutputFolder>
+        
+        <TargetFramework>net6.0-windows</TargetFramework>
+        <UnityEditor2020 Condition="'$(UnityEditor2020)' == ''">$(Unity2020)/Editor/Unity</UnityEditor2020>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Reference Include="$(BepInExCore)/BepInEx.Core.dll" Private="false"/>
+        <Reference Include="$(BepInExCore)/BepInEx.Preloader.Core.dll" Private="false"/>
+        <Reference Include="$(BepInExCore)/BepInEx.Unity.IL2CPP.dll" Private="false"/>
+        <Reference Include="$(BepInExCore)/Mono.Cecil.dll" Private="false"/>
+        <Reference Include="$(BepInExCore)/Mono.Cecil.Mdb.dll" Private="false"/>
+        <Reference Include="$(BepInExCore)/Mono.Cecil.Pdb.dll" Private="false"/>
+        <Reference Include="$(BepInExCore)/Mono.Cecil.Rocks.dll" Private="false"/>
+    </ItemGroup>
+
+    <Target Name="CopyAssembliesToMods" AfterTargets="Build" Condition="Exists('$(TargetDir)$(TargetName).dll')">
+        <ItemGroup>
+            <ArtefactFiles Include="$(TargetDir)DiscoAPI.Preload.dll;$(TargetDir)DiscoAPI.Preload.pdb" />
+        </ItemGroup>
+    
+        <Message Text="Copying assemblies to $(OutputFolder):%0A    * @(ArtefactFiles, '%0A    * ')" Importance="high" />    
+
+        <Copy SourceFiles="@(ArtefactFiles)"
+              DestinationFolder="$(OutputFolder)/%(RecursiveDir)" />
+        
+    </Target>
+
+</Project>

--- a/Preload.csproj
+++ b/Preload.csproj
@@ -32,6 +32,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <Reference Include="$(BepInExCore)/BepInEx.Core.dll" Private="false"/>
         <Reference Include="$(BepInExCore)/BepInEx.Preloader.Core.dll" Private="false"/>
     </ItemGroup>
 

--- a/Preload.sln
+++ b/Preload.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Preload", "Preload.csproj", "{FACE61B5-E710-4AB4-97D7-8C56CC077550}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FACE61B5-E710-4AB4-97D7-8C56CC077550}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FACE61B5-E710-4AB4-97D7-8C56CC077550}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FACE61B5-E710-4AB4-97D7-8C56CC077550}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FACE61B5-E710-4AB4-97D7-8C56CC077550}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/disco.targets
+++ b/disco.targets
@@ -187,9 +187,6 @@
 
         <Copy SourceFiles="@(ArtefactFiles)"
               DestinationFolder="$(OutputFolder)/%(RecursiveDir)" />
-        
-        <Copy SourceFiles="$(TargetDir)Newtonsoft.Json.dll" Condition="Exists('$(TargetDir)Newtonsoft.Json.dll')"
-              DestinationFolder="$(BepInExInterop)" />
     </Target>
 </Project>
 

--- a/src/Preload/DllConflictResolver.cs
+++ b/src/Preload/DllConflictResolver.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+using BepInEx.Preloader.Core.Patching;
+
+namespace DiscoAPI.Preload;
+
+[PatcherPluginInfo("DiscoAPI.Preload", "DiscoAPI.Preload", "0.0.1")]
+public class DllConflictResolverPatch : BasePatcher
+{
+    private const string ProvidedNewtonsoftPath = "BepInEx/plugins/DiscoAPI/Newtonsoft.Json.dll";
+    
+    public override void Initialize()
+    {
+        Assembly.LoadFrom(ProvidedNewtonsoftPath);
+    }
+}

--- a/src/Preload/DllConflictResolver.cs
+++ b/src/Preload/DllConflictResolver.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Reflection;
 using BepInEx.Preloader.Core.Patching;
 
@@ -10,6 +11,12 @@ public class DllConflictResolverPatch : BasePatcher
     
     public override void Initialize()
     {
+        if (!File.Exists(ProvidedNewtonsoftPath))
+        {
+            this.Log.LogWarning("Attempted to patch Newtonsoft.Json but the replacement library cannot be found! Path: " + ProvidedNewtonsoftPath);
+            return;
+        }
+        
         Assembly.LoadFrom(ProvidedNewtonsoftPath);
     }
 }


### PR DESCRIPTION
We had two libraries using Newtonsoft.Json but targeting conflicting DLL versions:

- The first instance comes from the game. BepInEx uses Cpp2IL to decompile Newtonsoft.Json and stores it in `BepInEx/interop`. 
- The second instance comes from DiscoAPI via a NuGet package and is copied to `BepInEx/plugins/DiscoAPI`.

The game uses Newtonsoft.Json version 12 and dAPI uses version 13. But BepInEx will load version 12 before 13, resulting in dAPI being unable to use the library.

My solution is a BepInEx preload patch that loads Newtonsoft.Json 13 before BepInEx can load 12 from `interop`. The side effect is that BepInEx's `InteropManager` will give a warning about a file already loaded.

**Question: Should we combine these three .NET projects under one solution? I've got a [wip single-solution branch](https://github.com/dont-call-abigail/DiscoAPI/tree/refactor/single-solution) going right now but I want to confer with others.**