### PR TITLE
Feat: API support for modded interior levels

### DIFF
--- a/src/Common/Assets/Area.cs
+++ b/src/Common/Assets/Area.cs
@@ -35,6 +35,7 @@ public record Area : Asset, IAssetRef<Area>
 
     public SceneProperties GetSceneProperties()
     {
+        // note: SceneProperties.DisplayName returns null due to missing localization
         return new SceneProperties()
         {
             SceneName = sceneName,

--- a/src/Common/Assets/Area.cs
+++ b/src/Common/Assets/Area.cs
@@ -11,7 +11,7 @@ public record Area : Asset, IAssetRef<Area>
     public readonly float customMaxZoomLimit;
     public readonly string navMeshLocation;
 
-    public Area(string areaId, string sceneName, string navMeshLocation, bool isOutside, int visualRadius = 14) : base(areaId)
+    public Area(string areaId, string sceneName, string navMeshLocation, bool isOutside, int visualRadius = 18) : base(areaId)
     {
         this.sceneName = sceneName;
         this.isOutside = isOutside;
@@ -19,7 +19,7 @@ public record Area : Asset, IAssetRef<Area>
         this.visualRadius = visualRadius;
     }
 
-    public Area(string areaId, string sceneName,  string navMeshLocation, bool isOutside, int visualRadius = 14, 
+    public Area(string areaId, string sceneName,  string navMeshLocation, bool isOutside, int visualRadius = 18, 
         bool isDreamScene = false, bool hasCustomZoomLimits = false, float customMinZoomLimit = 0f, 
         float customMaxZoomLimit = 0f) : base(areaId)
     {

--- a/src/Common/Assets/Area.cs
+++ b/src/Common/Assets/Area.cs
@@ -2,29 +2,29 @@ namespace DiscoAPI.Common.Assets;
 
 public record Area : Asset, IAssetRef<Area>
 {
-    public readonly string sceneName;
+    public readonly string scenePath;
     public readonly int visualRadius;
     public readonly bool isOutside;
     public readonly bool isDreamScene;
     public readonly bool hasCustomZoomLimits;
     public readonly float customMinZoomLimit;
     public readonly float customMaxZoomLimit;
-    public readonly string navMeshLocation;
+    public readonly string navMeshPath;
 
-    public Area(string areaId, string sceneName, string navMeshLocation, bool isOutside, int visualRadius = 18) : base(areaId)
+    public Area(string areaId, string scenePath, string navMeshPath, bool isOutside, int visualRadius = 18) : base(areaId)
     {
-        this.sceneName = sceneName;
+        this.scenePath = scenePath;
         this.isOutside = isOutside;
-        this.navMeshLocation = navMeshLocation;
+        this.navMeshPath = navMeshPath;
         this.visualRadius = visualRadius;
     }
 
-    public Area(string areaId, string sceneName,  string navMeshLocation, bool isOutside, int visualRadius = 18, 
+    public Area(string areaId, string scenePath,  string navMeshPath, bool isOutside, int visualRadius = 18, 
         bool isDreamScene = false, bool hasCustomZoomLimits = false, float customMinZoomLimit = 0f, 
         float customMaxZoomLimit = 0f) : base(areaId)
     {
-        this.sceneName = sceneName;
-        this.navMeshLocation = navMeshLocation;
+        this.scenePath = scenePath;
+        this.navMeshPath = navMeshPath;
         this.isOutside = isOutside;
         this.isDreamScene = isDreamScene;
         this.visualRadius = visualRadius;
@@ -38,7 +38,7 @@ public record Area : Asset, IAssetRef<Area>
         // note: SceneProperties.DisplayName returns null due to missing localization
         return new SceneProperties()
         {
-            SceneName = sceneName,
+            SceneName = scenePath,
             SceneId = id,
             SaveGameId = id,
             VisualRadius = visualRadius,

--- a/src/Common/Assets/Area.cs
+++ b/src/Common/Assets/Area.cs
@@ -1,0 +1,54 @@
+namespace DiscoAPI.Common.Assets;
+
+public record Area : Asset, IAssetRef<Area>
+{
+    public readonly string sceneName;
+    public readonly int visualRadius;
+    public readonly bool isOutside;
+    public readonly bool isDreamScene;
+    public readonly bool hasCustomZoomLimits;
+    public readonly float customMinZoomLimit;
+    public readonly float customMaxZoomLimit;
+    public readonly string navMeshLocation;
+
+    public Area(string areaId, string sceneName, string navMeshLocation, bool isOutside, int visualRadius = 14) : base(areaId)
+    {
+        this.sceneName = sceneName;
+        this.isOutside = isOutside;
+        this.navMeshLocation = navMeshLocation;
+        this.visualRadius = visualRadius;
+    }
+
+    public Area(string areaId, string sceneName,  string navMeshLocation, bool isOutside, int visualRadius = 14, 
+        bool isDreamScene = false, bool hasCustomZoomLimits = false, float customMinZoomLimit = 0f, 
+        float customMaxZoomLimit = 0f) : base(areaId)
+    {
+        this.sceneName = sceneName;
+        this.navMeshLocation = navMeshLocation;
+        this.isOutside = isOutside;
+        this.isDreamScene = isDreamScene;
+        this.visualRadius = visualRadius;
+        this.hasCustomZoomLimits = hasCustomZoomLimits;
+        this.customMinZoomLimit = customMinZoomLimit;
+        this.customMaxZoomLimit = customMaxZoomLimit;
+    }
+
+    public SceneProperties GetSceneProperties()
+    {
+        return new SceneProperties()
+        {
+            SceneName = sceneName,
+            SceneId = id,
+            SaveGameId = id,
+            VisualRadius = visualRadius,
+            IsOutside = isOutside,
+            IsDreamScene = isDreamScene,
+            HasCustomZoomLimits = hasCustomZoomLimits,
+            CustomMinimumZoomLimit = customMinZoomLimit,
+            CustomMaximumZoomLimit = customMaxZoomLimit
+        };
+    }
+
+    public new AssetLocation<Area> Location => new(source, id);
+    Area? IAssetRef<Area>.Resolve(IDiscoManager mgr) => (Area?)((IAssetRef)this).Resolve(mgr);
+}

--- a/src/Runtime/Assets/Arenas.cs
+++ b/src/Runtime/Assets/Arenas.cs
@@ -96,7 +96,7 @@ public interface IRawArena<T>
 	IAssetArena<T> Raw { get; }
 }
 
-public class AssetArena<T> : IAssetArena<T>
+public class GenericArena<T> : IAssetArena<T>
 {
 	public readonly List<T> Items = new();
 	public int Count => Items.Count;

--- a/src/Runtime/Assets/Arenas.cs
+++ b/src/Runtime/Assets/Arenas.cs
@@ -96,7 +96,7 @@ public interface IRawArena<T>
 	IAssetArena<T> Raw { get; }
 }
 
-public class GenericArena<T> : IAssetArena<T>
+public class AssetArena<T> : IAssetArena<T>
 {
 	public readonly List<T> Items = new();
 	public int Count => Items.Count;
@@ -107,7 +107,6 @@ public class GenericArena<T> : IAssetArena<T>
 
 	public T? this[int id] => Items[id];
 }
-
 
 public class PCRawArena<T> : IAssetArena<T> where T : PC.Asset, new()
 {

--- a/src/Runtime/Components/World.cs
+++ b/src/Runtime/Components/World.cs
@@ -1,8 +1,10 @@
 using SM = Sunshine.Metric;
+using DiscoAPI.Common.Assets;
 
-namespace DiscoAPI.Runtime.Components;
-
-public static class WorldComponents
+=======
+using DiscoAPI.Common.Assets;
+using DiscoAPI.Runtime.Assets;
+>>>>>>> e335c7b (feat(areas): better constructors, arena fetching func)public static class WorldComponents
 {
 	public static ModEntityRegistry<World> Registry { get; }
 		= new(new PersistentEntityMap<World>(s => new(Registry!, s)));
@@ -13,4 +15,7 @@ public static class WorldComponents
 	{
 		return CharacterComponents.Of(s.EntityBase.you);
 	}
+
+	public static IAssetArena<Area> Areas => DiscoRunner.manager.Assets.GetArena<Area>();
+
 }

--- a/src/Runtime/Components/World.cs
+++ b/src/Runtime/Components/World.cs
@@ -1,10 +1,10 @@
 using SM = Sunshine.Metric;
 using DiscoAPI.Common.Assets;
-
-=======
-using DiscoAPI.Common.Assets;
 using DiscoAPI.Runtime.Assets;
->>>>>>> e335c7b (feat(areas): better constructors, arena fetching func)public static class WorldComponents
+
+namespace DiscoAPI.Runtime.Components;
+
+public static class WorldComponents
 {
 	public static ModEntityRegistry<World> Registry { get; }
 		= new(new PersistentEntityMap<World>(s => new(Registry!, s)));

--- a/src/Runtime/InherentProvider.cs
+++ b/src/Runtime/InherentProvider.cs
@@ -38,13 +38,14 @@ public static class InherentProvider
 		assets.Register(new PCArena<PC.Variable, Variable>(mgr => mgr.pcDatabase.variables), true);
 		assets.Register(new EnumArena<SM.SkillType, Skill>(SkillUtils.RecoverSkill, SkillUtils.SkillIsReal), true);
 		assets.Register(new PCProxyArena<Task, PC.Conversation>(convos.Raw, (conv) => conv.FieldExists("display_condition_main")), false);
-		
+		assets.Register(new AssetArena<Area>(), false);
+
 		DiscoHooks.OnDialogueLoad += OnDialogueBundleLoad;
 		DiscoHooks.OnSaveGame += save =>
 		{
 			var mod = save.GetModData(source.Guid);
 			mod.SetObject("you", DiscoRunner.world!.You().Serialize());
-			mod.SetObject("world", DiscoRunner.world.Serialize());
+			mod.SetObject("world", DiscoRunner.world!.Serialize());
 		};
 		DiscoHooks.OnLoadSavedGame += save =>
 		{

--- a/src/Runtime/InherentProvider.cs
+++ b/src/Runtime/InherentProvider.cs
@@ -38,8 +38,8 @@ public static class InherentProvider
 		assets.Register(new PCArena<PC.Variable, Variable>(mgr => mgr.pcDatabase.variables), true);
 		assets.Register(new EnumArena<SM.SkillType, Skill>(SkillUtils.RecoverSkill, SkillUtils.SkillIsReal), true);
 		assets.Register(new PCProxyArena<Task, PC.Conversation>(convos.Raw, (conv) => conv.FieldExists("display_condition_main")), false);
-		assets.Register(new AssetArena<Area>(), false);
-
+		assets.Register(new GenericArena<Area>(), false);
+		
 		DiscoHooks.OnDialogueLoad += OnDialogueBundleLoad;
 		DiscoHooks.OnSaveGame += save =>
 		{

--- a/src/Runtime/Patches/Areas.cs
+++ b/src/Runtime/Patches/Areas.cs
@@ -1,14 +1,80 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using AddressablesTools;
+using BepInEx.Unity.IL2CPP.Utils.Collections;
+using DiscoAPI.Common.Assets;
+using DiscoAPI.Runtime.Components;
 using FortressOccident;
 using HarmonyLib;
+using Sunshine;
+using UnityEngine;
+using UnityEngine.AI;
+using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.SceneManagement;
 
 namespace DiscoAPI.Runtime.Patches;
 
 public static class AreaPatches
 {
+    
     [HarmonyPatch(typeof(ApplicationManager), nameof(ApplicationManager.ChangeArea))]
     [HarmonyPrefix]
-    private static void OnChangeArea(string areaId, string destinationId, bool isGameLoad)
+    private static void OnChangeArea(string areaId, string destinationId, ref bool isGameLoad)
     {
-        
+        Area? foundArea = ModWorld.Areas.FirstOrDefault(a => a.id == areaId);
+        if (foundArea == default)
+        {
+            ModAreaState.isLoadingModState = false;
+            return;
+        }
+
+        ModAreaState.isLoadingModState = true;
+        ApplicationManager.Singleton.ScenePropertiesList.Add(foundArea.GetSceneProperties());
+        // resolve navmesh asset
+        FastLoadManager.m_FastLoadManager.navMeshDataCollection.NavMeshes.Add(null);
+        FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict.Add(foundArea.sceneName, null);
     }
+
+
+    [HarmonyPatch(typeof(SceneTransitionManager), nameof(SceneTransitionManager.LoadSceneCoR))]
+    [HarmonyPrefix]
+    private static void OnLoadSceneCoR(string sceneName, string destinationId, bool showLoadingScreen,
+        bool hideLoadingScreen, bool isMapChanging)
+    {
+        if (!ModAreaState.isLoadingModState) return;
+        var scene = LoadModScene(sceneName, ModAreaState.bundleName);
+        FastLoadManager.m_FastLoadManager.allScenes.Add(sceneName, scene);
+    }
+    
+    [HarmonyPatch(typeof(SceneTransitionManager), nameof(SceneTransitionManager.LoadSceneCoR))]
+    [HarmonyPostfix]
+    private static void OnLoadSceneCoRPostfix(string sceneName, string destinationId, bool showLoadingScreen,
+        bool hideLoadingScreen, bool isMapChanging)
+    {
+        if (!ModAreaState.isLoadingModState) return;
+        NavMesh.RemoveAllNavMeshData();
+        NavMesh.AddNavMeshData(FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict[sceneName]);
+    }
+
+    private static Scene LoadModScene(string sceneName, string bundleName, string aliasPrefix = "")
+    {
+        var bundle = new AssetBundleRoute<Scene>(bundleName, aliasPrefix);
+        var loadOp = bundle.Get(sceneName);
+        var result = loadOp.WaitForCompletion();
+
+        if (loadOp.Status == AsyncOperationStatus.Failed)
+        {
+            DiscoRunner.Log.LogError($"could not load {sceneName} from bundle {bundleName}!");
+            return default;
+        }
+
+        return result;
+    }
+}
+
+internal static class ModAreaState
+{
+    public static string bundleName = "scenes";
+    public static bool isLoadingModState;
 }

--- a/src/Runtime/Patches/Areas.cs
+++ b/src/Runtime/Patches/Areas.cs
@@ -1,8 +1,6 @@
 using System.Linq;
 using BepInEx.Unity.IL2CPP.Utils.Collections;
 using DiscoAPI.Common.Assets;
-using DiscoAPI.Runtime.Assets;
-using DiscoAPI.Runtime.Components;
 using FortressOccident;
 using HarmonyLib;
 using Il2CppSystem.Collections;
@@ -14,37 +12,60 @@ namespace DiscoAPI.Runtime.Patches;
 
 public static class AreaPatches
 {
-    
     [HarmonyPatch(typeof(ApplicationManager), nameof(ApplicationManager.ChangeArea))]
     [HarmonyPrefix]
-    private static void OnChangeArea(string areaId, string destinationId, ref bool isGameLoad)
+    private static void OnChangeArea(ApplicationManager __instance, string areaId, string destinationId, ref bool isGameLoad)
     {
-        Area? foundArea = AreaUtils.Areas.FirstOrDefault(a => a.id == areaId);
-        if (foundArea == null)
+        if (__instance.CurrentSceneProperties != null)
         {
-            return;
+            var currentScene = __instance.CurrentSceneProperties.SceneName;
+            Area? foundPresentArea = AreaUtils.FromScenePath(currentScene);
+            if (foundPresentArea != null)
+            {
+                __instance.ScenePropertiesList.Remove(foundPresentArea.GetSceneProperties());
+                FastLoadManager.m_FastLoadManager.StartCoroutine(UnloadArea(foundPresentArea).WrapToIl2Cpp());
+            }
         }
+
+        Area? foundNextArea = AreaUtils.Areas.FirstOrDefault(a => a.id == areaId);
+        if (foundNextArea == null) return;
         
-        ApplicationManager.Singleton.ScenePropertiesList.Add(foundArea.GetSceneProperties());
+        __instance.ScenePropertiesList.Add(foundNextArea.GetSceneProperties());
+    }
+    
+    private static System.Collections.IEnumerator UnloadArea(Area area)
+    {
+        var oldSceneFound = FastLoadManager.m_FastLoadManager.allScenes.TryGetValue(area.scenePath, out Scene oldScene);
+        if (!oldSceneFound)
+        {
+            DiscoRunner.Log.LogError($"called to unload scene {area.scenePath} that was not loaded in FastLoadManager!");
+            yield break;
+        }
+
+        FastLoadManager.m_FastLoadManager.allScenes.Remove(area.scenePath);
+        
+        yield return SceneManager.UnloadSceneAsync(oldScene);
+        yield return null;
+
+        Resources.UnloadUnusedAssets();
+        DiscoRunner.Log.LogInfo($"unload of area '{area.id}' complete");
     }
     
     [HarmonyPatch(typeof(SceneTransitionManager), nameof(SceneTransitionManager.LoadSceneCoR))]
     [HarmonyPostfix]
-    private static void OnLoadSceneCoRPostfix(ref IEnumerator __result, IEnumerator __state, string sceneName, string destinationId, bool showLoadingScreen,
+    private static void OnLoadSceneCoRPostfix(ref IEnumerator __result, string sceneName, string destinationId, bool showLoadingScreen,
         bool hideLoadingScreen, bool isMapChanging)
     {
-        if (!AreaUtils.TryFromSceneName(sceneName, out Area foundArea))
-        {
-            return;
-        }
+        var foundArea = AreaUtils.FromScenePath(sceneName); // sceneName is actually a path
+        if (foundArea == null) return;
         
-        __result = SpecialRoutine(__result, foundArea).WrapToIl2Cpp();
+        __result = PatchedSceneLoadRoutine(__result, foundArea).WrapToIl2Cpp();
     }
 
-    private static System.Collections.IEnumerator SpecialRoutine(IEnumerator original, Area foundArea)
+    private static System.Collections.IEnumerator PatchedSceneLoadRoutine(IEnumerator original, Area foundArea)
     {
         yield return AreaUtils.LoadModScene(foundArea);
-        FastLoadManager.m_FastLoadManager.allScenes.Add(foundArea.sceneName, SceneManager.GetSceneAt(SceneManager.sceneCount - 1));
+        FastLoadManager.m_FastLoadManager.allScenes.TryAdd(foundArea.scenePath, SceneManager.GetSceneAt(SceneManager.sceneCount - 1));
 
         yield return null;
         
@@ -56,18 +77,13 @@ public static class AreaPatches
     [HarmonyPrefix]
     private static bool OnGetNavMeshDataByScene(ref NavMeshData __result, string scenePath)
     {
-        var sceneWithNoPathHardcode = scenePath[14..^6];
-        var trueScenePath =
-            FastLoadManager.m_FastLoadManager.allScenes.entries.FirstOrDefault(s => s.key.Contains(sceneWithNoPathHardcode));
-        if (trueScenePath == null || !AreaUtils.TryFromSceneName(trueScenePath.key, out Area foundArea))
-        {
-            return true;
-        }
-        
+        var sceneNameNoHardcodePath = scenePath[14..^6];
+        var foundArea = AreaUtils.FromSceneName(sceneNameNoHardcodePath);
+        if (foundArea == null) return true;
+
         var navMesh = AreaUtils.LoadNavmeshData(foundArea);
-        FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict.Add(foundArea.sceneName, navMesh);
         __result = navMesh;
         return false;
     }
-    
+
 }

--- a/src/Runtime/Patches/Areas.cs
+++ b/src/Runtime/Patches/Areas.cs
@@ -65,24 +65,33 @@ public static class AreaPatches
     private static System.Collections.IEnumerator PatchedSceneLoadRoutine(IEnumerator original, Area foundArea)
     {
         yield return AreaUtils.LoadModScene(foundArea);
+        
         FastLoadManager.m_FastLoadManager.allScenes.TryAdd(foundArea.scenePath, SceneManager.GetSceneAt(SceneManager.sceneCount - 1));
 
         yield return null;
         
+        if (!FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict.ContainsKey(foundArea.id))
+        {
+            var navLoadOp = AreaUtils.LoadNavmeshData(foundArea);
+            yield return navLoadOp;
+            
+            FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict.Add(foundArea.id, navLoadOp.Result);
+        }
+
         while (original.MoveNext())
             yield return original.Current;
     }
+
 
     [HarmonyPatch(typeof(NavMeshDataCollection), nameof(NavMeshDataCollection.GetNavMeshDataByScene))]
     [HarmonyPrefix]
     private static bool OnGetNavMeshDataByScene(ref NavMeshData __result, string scenePath)
     {
         var sceneNameNoHardcodePath = scenePath[14..^6];
-        var foundArea = AreaUtils.FromSceneName(sceneNameNoHardcodePath);
+        var foundArea = AreaUtils.Areas.FirstOrDefault(a => a.id == sceneNameNoHardcodePath);
         if (foundArea == null) return true;
 
-        var navMesh = AreaUtils.LoadNavmeshData(foundArea);
-        __result = navMesh;
+        __result = FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict[sceneNameNoHardcodePath];
         return false;
     }
 

--- a/src/Runtime/Patches/Areas.cs
+++ b/src/Runtime/Patches/Areas.cs
@@ -1,16 +1,12 @@
-using System.Collections;
-using System.Collections.Generic;
 using System.Linq;
-using AddressablesTools;
-using BepInEx.Unity.IL2CPP.Utils.Collections;
 using DiscoAPI.Common.Assets;
+using DiscoAPI.Runtime.Assets;
 using DiscoAPI.Runtime.Components;
 using FortressOccident;
 using HarmonyLib;
-using Sunshine;
+using Il2CppSystem.Collections;
 using UnityEngine;
 using UnityEngine.AI;
-using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.SceneManagement;
 
 namespace DiscoAPI.Runtime.Patches;
@@ -22,7 +18,7 @@ public static class AreaPatches
     [HarmonyPrefix]
     private static void OnChangeArea(string areaId, string destinationId, ref bool isGameLoad)
     {
-        Area? foundArea = ModWorld.Areas.FirstOrDefault(a => a.id == areaId);
+        Area? foundArea = ModAreaState.Areas.FirstOrDefault(a => a.id == areaId);
         if (foundArea == default)
         {
             ModAreaState.isLoadingModState = false;
@@ -31,9 +27,9 @@ public static class AreaPatches
 
         ModAreaState.isLoadingModState = true;
         ApplicationManager.Singleton.ScenePropertiesList.Add(foundArea.GetSceneProperties());
-        // resolve navmesh asset
-        FastLoadManager.m_FastLoadManager.navMeshDataCollection.NavMeshes.Add(null);
-        FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict.Add(foundArea.sceneName, null);
+        
+        var navMesh = LoadNavmeshData(foundArea.navMeshLocation, ModAreaState.bundleName);
+        FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict.Add(foundArea.sceneName, navMesh);
     }
 
 
@@ -49,32 +45,43 @@ public static class AreaPatches
     
     [HarmonyPatch(typeof(SceneTransitionManager), nameof(SceneTransitionManager.LoadSceneCoR))]
     [HarmonyPostfix]
-    private static void OnLoadSceneCoRPostfix(string sceneName, string destinationId, bool showLoadingScreen,
-        bool hideLoadingScreen, bool isMapChanging)
+    private static System.Collections.IEnumerator OnLoadSceneCoRPostfix(string sceneName, string destinationId, bool showLoadingScreen,
+        bool hideLoadingScreen, bool isMapChanging, IEnumerator __result)
     {
-        if (!ModAreaState.isLoadingModState) return;
+        while (__result.MoveNext())
+            yield return __result.Current;
+        
+        if (!ModAreaState.isLoadingModState) yield break;
         NavMesh.RemoveAllNavMeshData();
         NavMesh.AddNavMeshData(FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict[sceneName]);
     }
 
     private static Scene LoadModScene(string sceneName, string bundleName, string aliasPrefix = "")
     {
-        var bundle = new AssetBundleRoute<Scene>(bundleName, aliasPrefix);
-        var loadOp = bundle.Get(sceneName);
-        var result = loadOp.WaitForCompletion();
+        ModAreaState.sceneBundle ??= AssetBundle.LoadFromFile(bundleName);
+        var scenePath = ModAreaState.sceneBundle.GetAllScenePaths().FirstOrDefault(s => s == sceneName);
 
-        if (loadOp.Status == AsyncOperationStatus.Failed)
+        if (scenePath == default)
         {
             DiscoRunner.Log.LogError($"could not load {sceneName} from bundle {bundleName}!");
             return default;
         }
 
-        return result;
+        return SceneManager.LoadScene(sceneName, new LoadSceneParameters() { loadSceneMode = LoadSceneMode.Additive });
+    }
+
+    private static NavMeshData LoadNavmeshData(string meshPath, string bundleName)
+    {
+        ModAreaState.sceneBundle ??= AssetBundle.LoadFromFile(bundleName);
+
+        return ModAreaState.sceneBundle.LoadAsset<NavMeshData>(meshPath);
     }
 }
 
 internal static class ModAreaState
 {
-    public static string bundleName = "scenes";
+    public static string bundleName = "BepInEx/plugins/dca/assetbundles/scenes";
     public static bool isLoadingModState;
+    public static AssetBundle? sceneBundle;
+    public static IAssetArena<Area> Areas => DiscoRunner.manager.Assets.GetArena<Area>();
 }

--- a/src/Runtime/Patches/Areas.cs
+++ b/src/Runtime/Patches/Areas.cs
@@ -1,0 +1,14 @@
+using FortressOccident;
+using HarmonyLib;
+
+namespace DiscoAPI.Runtime.Patches;
+
+public static class AreaPatches
+{
+    [HarmonyPatch(typeof(ApplicationManager), nameof(ApplicationManager.ChangeArea))]
+    [HarmonyPrefix]
+    private static void OnChangeArea(string areaId, string destinationId, bool isGameLoad)
+    {
+        
+    }
+}

--- a/src/Runtime/Patches/Areas.cs
+++ b/src/Runtime/Patches/Areas.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using BepInEx.Unity.IL2CPP.Utils.Collections;
 using DiscoAPI.Common.Assets;
 using DiscoAPI.Runtime.Assets;
 using DiscoAPI.Runtime.Components;
@@ -19,47 +20,54 @@ public static class AreaPatches
     private static void OnChangeArea(string areaId, string destinationId, ref bool isGameLoad)
     {
         Area? foundArea = AreaUtils.Areas.FirstOrDefault(a => a.id == areaId);
-        if (foundArea == default)
+        if (foundArea == null)
         {
             return;
         }
         
         ApplicationManager.Singleton.ScenePropertiesList.Add(foundArea.GetSceneProperties());
-        
-        var navMesh = LoadNavmeshData(foundArea.navMeshLocation, "");
-        FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict.Add(foundArea.sceneName, navMesh);
-    }
-
-
-    [HarmonyPatch(typeof(SceneTransitionManager), nameof(SceneTransitionManager.LoadSceneCoR))]
-    [HarmonyPrefix]
-    private static void OnLoadSceneCoR(string sceneName, string destinationId, bool showLoadingScreen,
-        bool hideLoadingScreen, bool isMapChanging)
-    {
-        if (!AreaUtils.IsModdedArea(sceneName)) return;
-        
-        var scene = AreaUtils.LoadModScene(AreaUtils.Areas.First(a => a.sceneName == sceneName));
-        FastLoadManager.m_FastLoadManager.allScenes.Add(sceneName, scene);
     }
     
     [HarmonyPatch(typeof(SceneTransitionManager), nameof(SceneTransitionManager.LoadSceneCoR))]
     [HarmonyPostfix]
-    private static System.Collections.IEnumerator OnLoadSceneCoRPostfix(string sceneName, string destinationId, bool showLoadingScreen,
-        bool hideLoadingScreen, bool isMapChanging, IEnumerator __result)
+    private static void OnLoadSceneCoRPostfix(ref IEnumerator __result, IEnumerator __state, string sceneName, string destinationId, bool showLoadingScreen,
+        bool hideLoadingScreen, bool isMapChanging)
     {
-        while (__result.MoveNext())
-            yield return __result.Current;
+        if (!AreaUtils.TryFromSceneName(sceneName, out Area foundArea))
+        {
+            return;
+        }
         
-        if (!AreaUtils.IsModdedArea(sceneName)) yield break;
-        NavMesh.RemoveAllNavMeshData();
-        NavMesh.AddNavMeshData(FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict[sceneName]);
+        __result = SpecialRoutine(__result, foundArea).WrapToIl2Cpp();
+    }
+
+    private static System.Collections.IEnumerator SpecialRoutine(IEnumerator original, Area foundArea)
+    {
+        yield return AreaUtils.LoadModScene(foundArea);
+        FastLoadManager.m_FastLoadManager.allScenes.Add(foundArea.sceneName, SceneManager.GetSceneAt(SceneManager.sceneCount - 1));
+
+        yield return null;
+        
+        while (original.MoveNext())
+            yield return original.Current;
+    }
+
+    [HarmonyPatch(typeof(NavMeshDataCollection), nameof(NavMeshDataCollection.GetNavMeshDataByScene))]
+    [HarmonyPrefix]
+    private static bool OnGetNavMeshDataByScene(ref NavMeshData __result, string scenePath)
+    {
+        var sceneWithNoPathHardcode = scenePath[14..^6];
+        var trueScenePath =
+            FastLoadManager.m_FastLoadManager.allScenes.entries.FirstOrDefault(s => s.key.Contains(sceneWithNoPathHardcode));
+        if (trueScenePath == null || !AreaUtils.TryFromSceneName(trueScenePath.key, out Area foundArea))
+        {
+            return true;
+        }
+        
+        var navMesh = AreaUtils.LoadNavmeshData(foundArea);
+        FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict.Add(foundArea.sceneName, navMesh);
+        __result = navMesh;
+        return false;
     }
     
-
-    private static NavMeshData LoadNavmeshData(string meshPath, string bundleName)
-    {
-        AreaUtils.sceneBundle ??= AssetBundle.LoadFromFile(bundleName);
-
-        return AreaUtils.sceneBundle.LoadAsset<NavMeshData>(meshPath);
-    }
 }

--- a/src/Runtime/Patches/Areas.cs
+++ b/src/Runtime/Patches/Areas.cs
@@ -18,17 +18,15 @@ public static class AreaPatches
     [HarmonyPrefix]
     private static void OnChangeArea(string areaId, string destinationId, ref bool isGameLoad)
     {
-        Area? foundArea = ModAreaState.Areas.FirstOrDefault(a => a.id == areaId);
+        Area? foundArea = AreaUtils.Areas.FirstOrDefault(a => a.id == areaId);
         if (foundArea == default)
         {
-            ModAreaState.isLoadingModState = false;
             return;
         }
-
-        ModAreaState.isLoadingModState = true;
+        
         ApplicationManager.Singleton.ScenePropertiesList.Add(foundArea.GetSceneProperties());
         
-        var navMesh = LoadNavmeshData(foundArea.navMeshLocation, ModAreaState.bundleName);
+        var navMesh = LoadNavmeshData(foundArea.navMeshLocation, "");
         FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict.Add(foundArea.sceneName, navMesh);
     }
 
@@ -38,8 +36,9 @@ public static class AreaPatches
     private static void OnLoadSceneCoR(string sceneName, string destinationId, bool showLoadingScreen,
         bool hideLoadingScreen, bool isMapChanging)
     {
-        if (!ModAreaState.isLoadingModState) return;
-        var scene = LoadModScene(sceneName, ModAreaState.bundleName);
+        if (!AreaUtils.IsModdedArea(sceneName)) return;
+        
+        var scene = AreaUtils.LoadModScene(AreaUtils.Areas.First(a => a.sceneName == sceneName));
         FastLoadManager.m_FastLoadManager.allScenes.Add(sceneName, scene);
     }
     
@@ -51,37 +50,16 @@ public static class AreaPatches
         while (__result.MoveNext())
             yield return __result.Current;
         
-        if (!ModAreaState.isLoadingModState) yield break;
+        if (!AreaUtils.IsModdedArea(sceneName)) yield break;
         NavMesh.RemoveAllNavMeshData();
         NavMesh.AddNavMeshData(FastLoadManager.m_FastLoadManager.navMeshDataCollection.dict[sceneName]);
     }
-
-    private static Scene LoadModScene(string sceneName, string bundleName, string aliasPrefix = "")
-    {
-        ModAreaState.sceneBundle ??= AssetBundle.LoadFromFile(bundleName);
-        var scenePath = ModAreaState.sceneBundle.GetAllScenePaths().FirstOrDefault(s => s == sceneName);
-
-        if (scenePath == default)
-        {
-            DiscoRunner.Log.LogError($"could not load {sceneName} from bundle {bundleName}!");
-            return default;
-        }
-
-        return SceneManager.LoadScene(sceneName, new LoadSceneParameters() { loadSceneMode = LoadSceneMode.Additive });
-    }
+    
 
     private static NavMeshData LoadNavmeshData(string meshPath, string bundleName)
     {
-        ModAreaState.sceneBundle ??= AssetBundle.LoadFromFile(bundleName);
+        AreaUtils.sceneBundle ??= AssetBundle.LoadFromFile(bundleName);
 
-        return ModAreaState.sceneBundle.LoadAsset<NavMeshData>(meshPath);
+        return AreaUtils.sceneBundle.LoadAsset<NavMeshData>(meshPath);
     }
-}
-
-internal static class ModAreaState
-{
-    public static string bundleName = "BepInEx/plugins/dca/assetbundles/scenes";
-    public static bool isLoadingModState;
-    public static AssetBundle? sceneBundle;
-    public static IAssetArena<Area> Areas => DiscoRunner.manager.Assets.GetArena<Area>();
 }

--- a/src/Runtime/Plugin.cs
+++ b/src/Runtime/Plugin.cs
@@ -51,8 +51,9 @@ public class DiscoAPIPlugin : BasePlugin
         PatchAll(typeof(Patches.MiscPatches));
         PatchAll(typeof(Patches.PersistencePatches));
         PatchAll(typeof(Patches.ArchetypePatches));
+        PatchAll(typeof(Patches.AreaPatches));
         // PatchAll(typeof(Patches.VirtualTexturePatches));
-        DialogueBundleLoader.bundleWasLoaded.AddListener((Action)DiscoRunner.OnDialogueBundleLoad);
+        DialoguBundleLoa der.bundleWasLoaded.AddListener((Action)DiscoRunner.OnDialogueBundleLoad);
 
         DiscoRunner.OnLoad();
     }

--- a/src/Runtime/Plugin.cs
+++ b/src/Runtime/Plugin.cs
@@ -53,7 +53,7 @@ public class DiscoAPIPlugin : BasePlugin
         PatchAll(typeof(Patches.ArchetypePatches));
         PatchAll(typeof(Patches.AreaPatches));
         // PatchAll(typeof(Patches.VirtualTexturePatches));
-        DialoguBundleLoa der.bundleWasLoaded.AddListener((Action)DiscoRunner.OnDialogueBundleLoad);
+        DialogueBundleLoader.bundleWasLoaded.AddListener((Action)DiscoRunner.OnDialogueBundleLoad);
 
         DiscoRunner.OnLoad();
     }

--- a/src/Runtime/UnityAssetRouter.cs
+++ b/src/Runtime/UnityAssetRouter.cs
@@ -101,7 +101,7 @@ public abstract class LooseFileRoute<T> : IAssetRoute<T> where T : UnityEngine.O
 {
 	public string? location;
 	private Dictionary<string, AsyncOperationHandle<T?>> cache = new();
-
+    
 	protected LooseFileRoute(string? location)
 	{
 		this.location = location;

--- a/src/Runtime/UnityAssetRouter.cs
+++ b/src/Runtime/UnityAssetRouter.cs
@@ -53,7 +53,19 @@ public class AssetBundleRoute<T> : IAssetRoute<T> where T : Il2CppObjectBase
 
 	private void Execute(string path, AssetUtils.Complete<T> complete)
 	{
-		var req = bundle.Result!.LoadAssetAsync<T>(aliasPrefix + path);
+		var finalPath = aliasPrefix + path;
+		var finalBundle = bundle.Result;
+		if (!finalBundle)
+		{
+			complete(null, $"failed to load bundle containing {finalPath}");
+			return;
+		}
+		if (!bundle.Result!.Contains(finalPath))
+		{
+			complete(null, $"failed to load {finalPath} from {bundle.Result.name}: does not exist in this bundle");
+			return;
+		}
+		var req = bundle.Result!.LoadAssetAsync<T>(finalPath);
 		req.add_completed((Action<AsyncOperation>)(_ => complete(req.GetResult().TryCast<T?>(), null)));
 	}
 

--- a/src/Runtime/UnityAssetRouter.cs
+++ b/src/Runtime/UnityAssetRouter.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
+using UnityEngine.AI;
 
 namespace DiscoAPI.Runtime;
 
@@ -26,7 +27,7 @@ public class AssetBundleRoute<T> : IAssetRoute<T> where T : Il2CppObjectBase
 	private AsyncOperationHandle<AssetBundle?> bundle;
 	private string aliasPrefix;
 
-	private static AsyncOperationHandle<AssetBundle?> HandleFromCreateRequest(AssetBundleCreateRequest req)
+	public static AsyncOperationHandle<AssetBundle?> HandleFromCreateRequest(AssetBundleCreateRequest req)
 	{
 		return AssetUtils.SpoofHandle<AssetBundle>(complete =>
 		{
@@ -58,6 +59,30 @@ public class AssetBundleRoute<T> : IAssetRoute<T> where T : Il2CppObjectBase
 
 	public AsyncOperationHandle<T?> Get(string path)
 		=> AssetUtils.SpoofHandle<T>(complete => Execute(path, complete), bundle);
+}
+
+public class SceneBundleRoute
+{
+	// necessary because Scenes in bundles are 1) not directly accessible
+	// and 2) do not inherit UnityEngine.Object or Il2CppObject
+	private AsyncOperationHandle<AssetBundle?>? bundle;
+	private string? bundlePath;
+
+	public SceneBundleRoute(string? bundlePath)
+	{
+		this.bundlePath = bundlePath;
+	}
+
+	public AsyncOperationHandle<AssetBundle?> Get()
+	{
+		if (bundle == null || !bundle.Result)
+		{
+			this.bundle =
+				AssetBundleRoute<AssetBundle>.HandleFromCreateRequest(AssetBundle.LoadFromFileAsync(bundlePath));
+		}
+
+		return bundle;
+	}
 }
 
 public abstract class LooseFileRoute<T> : IAssetRoute<T> where T : UnityEngine.Object
@@ -117,6 +142,8 @@ public class LooseSpriteRoute : LooseFileRoute<Sprite>
 public interface IAssetRouter
 {
 	IAssetRoute<Sprite> Portraits => new EmptyAssetRoute<Sprite>();
+	SceneBundleRoute SceneBundle => new SceneBundleRoute("UNDEFINED");
+	IAssetRoute<NavMeshData> NavMeshes => new EmptyAssetRoute<NavMeshData>();
 	IAssetRoute<AudioClip> ClipsForConversation(IAssetRef<Conversation> conversation) => new EmptyAssetRoute<AudioClip>();
 }
 
@@ -131,10 +158,18 @@ public class MemoizedAssetRouter : IAssetRouter
 		this.inner = inner;
 
 		portraits = new(() => inner.Portraits);
+		scenes = new(() => inner.SceneBundle);
+		navmeshes = new(() => inner.NavMeshes);
 	}
 
 	private Lazy<IAssetRoute<Sprite>> portraits;
 	public IAssetRoute<Sprite> Portraits => portraits.Value;
+
+	private Lazy<SceneBundleRoute> scenes;
+	public SceneBundleRoute SceneBundle => scenes.Value;
+
+	private Lazy<IAssetRoute<NavMeshData>> navmeshes;
+	public IAssetRoute<NavMeshData> NavMeshes => navmeshes.Value;
 
 	private Dictionary<AssetLocation, IAssetRoute<AudioClip>> clipsForConversation = new();
 	public IAssetRoute<AudioClip> ClipsForConversation(IAssetRef<Conversation> conversation)

--- a/src/Runtime/Utils.cs
+++ b/src/Runtime/Utils.cs
@@ -117,7 +117,6 @@ namespace DiscoAPI.Runtime
 				DiscoRunner.Log.LogWarning("unexpected null modifiable");
 				return null;
 			}
-
 			// excellent example of why il2cpp is a bit weird:
 			if (modifiable.GetIl2CppType() == Il2CppType.Of<SM.Skill>())
 				return GetActorSkillName(modifiable.Cast<SM.Skill>().skillType);
@@ -159,7 +158,7 @@ namespace DiscoAPI.Runtime
 		public static bool SkillIsReal(SM.SkillType skill) => skill switch
 		{
 			SM.SkillType.NONE
-				or SM.SkillType.ALT => false,
+			or SM.SkillType.ALT => false,
 			_ => true
 		};
 
@@ -168,17 +167,16 @@ namespace DiscoAPI.Runtime
 		public static bool IsExcludedFromPortraits(SM.SkillType type) => type switch
 		{
 			SM.SkillType.NONE
-				or SM.SkillType.CONVALESCENCE
-				or SM.SkillType.HEARING
-				or SM.SkillType.SIGHT
-				or SM.SkillType.SMELL
-				or SM.SkillType.TASTE
-				or SM.SkillType.ALT => true,
+			or SM.SkillType.CONVALESCENCE
+			or SM.SkillType.HEARING
+			or SM.SkillType.SIGHT
+			or SM.SkillType.SMELL
+			or SM.SkillType.TASTE
+			or SM.SkillType.ALT => true,
 			_ => false,
 		};
 
-		public static EnumArena<SM.SkillType, Skill> Skills =>
-			(EnumArena<SM.SkillType, Skill>)DiscoRunner.manager.Assets.GetArena<Skill>();
+		public static EnumArena<SM.SkillType, Skill> Skills => (EnumArena<SM.SkillType, Skill>)DiscoRunner.manager.Assets.GetArena<Skill>();
 
 		public static Skill? Lookup(SM.SkillType st) => Skills[Skills.ReverseId(st)];
 
@@ -215,29 +213,26 @@ namespace DiscoAPI.Runtime
 	public static class AssetUtils
 	{
 		public const string EXTRA_TEXTURE_PREFIX = "\0EXTRA\0";
-
-		public static AsyncOperationHandle<Sprite?> LoadPortrait(string textureName,
-			Il2CppSystem.Action<AsyncOperationHandle<Sprite?>>? del)
+		public static AsyncOperationHandle<Sprite?> LoadPortrait(string textureName, Il2CppSystem.Action<AsyncOperationHandle<Sprite?>> del)
 		{
 			if (PixelsToDisco.TryDecodeTextureName(textureName, out string? source, out string? path))
 			{
 				var handle = DiscoRunner.GetSource(source)!.Router.Portraits.Get(path);
-				if (del != null) handle.add_Completed(del);
+				handle.add_Completed(del);
 				return handle;
 			}
 			else return ActorsPortraitsBundleManager.LoadPortraitSpriteAsync(textureName, del);
+
 		}
 
 		public delegate void Complete<T>(T? result, string? error);
 
-		public static AsyncOperationHandle<T?> SpoofHandle<T>(System.Action<Complete<T>> execute)
-			where T : Il2CppObjectBase
+		public static AsyncOperationHandle<T?> SpoofHandle<T>(Action<Complete<T>> execute) where T : Il2CppObjectBase
 		{
 			return SpoofHandle<T>(execute, new());
 		}
 
-		public static AsyncOperationHandle<T?> SpoofHandle<T>(System.Action<Complete<T>> execute,
-			AsyncOperationHandle dep) where T : Il2CppObjectBase
+		public static AsyncOperationHandle<T?> SpoofHandle<T>(Action<Complete<T>> execute, AsyncOperationHandle dep)
 		{
 			// please don't ask why this is like this.
 
@@ -259,7 +254,7 @@ namespace DiscoAPI.Runtime
 				execute((res, err) =>
 				{
 					bool success = string.IsNullOrEmpty(err);
-					if (!success) res = null;
+					if (!success) res = default(T);
 					op.Complete(res, success, err, false);
 				});
 				op.HasExecuted = true;
@@ -374,7 +369,7 @@ namespace DiscoAPI.Runtime
 
 namespace System.Runtime.CompilerServices
 {
-	
+
 	internal class IsUnmanagedAttribute : Attribute
 	{
 		public IsUnmanagedAttribute()

--- a/src/Runtime/Utils.cs
+++ b/src/Runtime/Utils.cs
@@ -13,6 +13,7 @@ using Il2CppInterop.Runtime.InteropTypes;
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.AI;
 using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.SceneManagement;
 using static UnityEngine.ResourceManagement.ResourceManager;
@@ -382,23 +383,39 @@ namespace System.Runtime.CompilerServices
 
 public static class AreaUtils
 {
-	const string bundleName = "BepInEx/plugins/dca/assetbundles/scenes";
+	const string sceneBundlePath = "BepInEx/plugins/dca/assetbundles/scenes";
+	const string navmeshBundlePath = "BepInEx/plugins/dca/assetbundles/navmeshes";
 	public static AssetBundle? sceneBundle;
+	public static AssetBundle? navmeshBundle;
 	public static IAssetArena<Area> Areas => DiscoRunner.manager.Assets.GetArena<Area>();
 	public static bool IsModdedArea(string sceneName) => Areas.Any(a => a.sceneName == sceneName);
-	
-	public static Scene LoadModScene(Area area)
+
+	public static bool TryFromSceneName(string sceneName, out Area area)
 	{
-		AreaUtils.sceneBundle ??= AssetBundle.LoadFromFile(bundleName);
+		var found = Areas.FirstOrDefault(a => a.sceneName == sceneName);
+		area = found!;
+		return found != null;
+	}
+	
+	public static AsyncOperation? LoadModScene(Area area)
+	{
+		AreaUtils.sceneBundle ??= AssetBundle.LoadFromFile(sceneBundlePath);
 		var scenePath = AreaUtils.sceneBundle.GetAllScenePaths().FirstOrDefault(s => s == area.sceneName);
 
-		if (scenePath == default)
+		if (scenePath == null)
 		{
-			DiscoRunner.Log.LogError($"could not load {area.sceneName} from bundle {bundleName}!");
-			return default;
+			DiscoRunner.Log.LogError($"could not load {area.sceneName} from bundle {sceneBundlePath}!");
+			return null;
 		}
-
-		return SceneManager.LoadScene(area.sceneName, new LoadSceneParameters() { loadSceneMode = LoadSceneMode.Additive });
+		
+		return SceneManager.LoadSceneAsync(area.sceneName, LoadSceneMode.Additive);
+	}
+	
+	public static NavMeshData LoadNavmeshData(Area area)
+	{
+		AreaUtils.navmeshBundle ??= AssetBundle.LoadFromFile(navmeshBundlePath);
+		var mesh = AreaUtils.navmeshBundle.LoadAsset<NavMeshData>(area.navMeshLocation);
+		return mesh;
 	}
 }
 

--- a/src/Runtime/Utils.cs
+++ b/src/Runtime/Utils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using DiscoAPI.Common.Assets;
@@ -13,6 +14,7 @@ using Il2CppInterop.Runtime.InteropTypes.Arrays;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.ResourceManagement.AsyncOperations;
+using UnityEngine.SceneManagement;
 using static UnityEngine.ResourceManagement.ResourceManager;
 using Action = System.Action;
 using Exception = System.Exception;
@@ -377,3 +379,26 @@ namespace System.Runtime.CompilerServices
 		}
 	}
 }
+
+public static class AreaUtils
+{
+	const string bundleName = "BepInEx/plugins/dca/assetbundles/scenes";
+	public static AssetBundle? sceneBundle;
+	public static IAssetArena<Area> Areas => DiscoRunner.manager.Assets.GetArena<Area>();
+	public static bool IsModdedArea(string sceneName) => Areas.Any(a => a.sceneName == sceneName);
+	
+	public static Scene LoadModScene(Area area)
+	{
+		AreaUtils.sceneBundle ??= AssetBundle.LoadFromFile(bundleName);
+		var scenePath = AreaUtils.sceneBundle.GetAllScenePaths().FirstOrDefault(s => s == area.sceneName);
+
+		if (scenePath == default)
+		{
+			DiscoRunner.Log.LogError($"could not load {area.sceneName} from bundle {bundleName}!");
+			return default;
+		}
+
+		return SceneManager.LoadScene(area.sceneName, new LoadSceneParameters() { loadSceneMode = LoadSceneMode.Additive });
+	}
+}
+

--- a/src/Runtime/Utils.cs
+++ b/src/Runtime/Utils.cs
@@ -7,6 +7,7 @@ using DiscoAPI.Common.Assets;
 using DiscoAPI.Common.Dialogue;
 using DiscoAPI.Runtime.Assets;
 using DiscoAPI.Runtime.Dialogue;
+using FortressOccident;
 using HarmonyLib;
 using Il2CppInterop.Runtime;
 using Il2CppInterop.Runtime.InteropTypes;
@@ -16,6 +17,7 @@ using UnityEngine.AddressableAssets;
 using UnityEngine.AI;
 using UnityEngine.ResourceManagement.AsyncOperations;
 using UnityEngine.SceneManagement;
+using Voidforge;
 using static UnityEngine.ResourceManagement.ResourceManager;
 using Action = System.Action;
 using Exception = System.Exception;
@@ -388,34 +390,35 @@ public static class AreaUtils
 	public static AssetBundle? sceneBundle;
 	public static AssetBundle? navmeshBundle;
 	public static IAssetArena<Area> Areas => DiscoRunner.manager.Assets.GetArena<Area>();
-	public static bool IsModdedArea(string sceneName) => Areas.Any(a => a.sceneName == sceneName);
-
-	public static bool TryFromSceneName(string sceneName, out Area area)
-	{
-		var found = Areas.FirstOrDefault(a => a.sceneName == sceneName);
-		area = found!;
-		return found != null;
-	}
+	public static bool IsModdedArea(string scenePath) => Areas.Any(a => a.scenePath == scenePath);
+	public static Area? FromScenePath(string scenePath) => Areas.FirstOrDefault(a => a.scenePath == scenePath);
+	public static Area? FromSceneName(string sceneName) => Areas.FirstOrDefault(a => a.scenePath.Contains(sceneName));
 	
 	public static AsyncOperation? LoadModScene(Area area)
 	{
 		AreaUtils.sceneBundle ??= AssetBundle.LoadFromFile(sceneBundlePath);
-		var scenePath = AreaUtils.sceneBundle.GetAllScenePaths().FirstOrDefault(s => s == area.sceneName);
+		var scenePath = AreaUtils.sceneBundle.GetAllScenePaths().FirstOrDefault(s => s == area.scenePath);
 
 		if (scenePath == null)
 		{
-			DiscoRunner.Log.LogError($"could not load {area.sceneName} from bundle {sceneBundlePath}!");
+			DiscoRunner.Log.LogError($"could not load {area.scenePath} from bundle {sceneBundlePath}!");
 			return null;
 		}
 		
-		return SceneManager.LoadSceneAsync(area.sceneName, LoadSceneMode.Additive);
+		return SceneManager.LoadSceneAsync(area.scenePath, LoadSceneMode.Additive);
 	}
 	
 	public static NavMeshData LoadNavmeshData(Area area)
 	{
 		AreaUtils.navmeshBundle ??= AssetBundle.LoadFromFile(navmeshBundlePath);
-		var mesh = AreaUtils.navmeshBundle.LoadAsset<NavMeshData>(area.navMeshLocation);
+		var mesh = AreaUtils.navmeshBundle.LoadAsset<NavMeshData>(area.navMeshPath);
 		return mesh;
+	}
+	
+	public static void ChangeArea(string areaId, string destinationId, bool isGameLoad, bool showLoadingScreen,
+		bool hideLoadingScreen)
+	{
+		SingletonScriptable<ApplicationManager>.Singleton.ChangeArea(areaId, destinationId, isGameLoad, showLoadingScreen, hideLoadingScreen);
 	}
 }
 

--- a/src/Runtime/Utils.cs
+++ b/src/Runtime/Utils.cs
@@ -261,7 +261,11 @@ namespace DiscoAPI.Runtime
 				execute((res, err) =>
 				{
 					bool success = string.IsNullOrEmpty(err);
-					if (!success) res = default(T);
+					if (!success)
+					{
+						DiscoRunner.Log.LogError(err);
+						res = default(T);
+					}
 					op.Complete(res, success, err, false);
 				});
 				op.HasExecuted = true;

--- a/src/Runtime/Utils.cs
+++ b/src/Runtime/Utils.cs
@@ -12,6 +12,7 @@ using HarmonyLib;
 using Il2CppInterop.Runtime;
 using Il2CppInterop.Runtime.InteropTypes;
 using Il2CppInterop.Runtime.InteropTypes.Arrays;
+using Il2CppSystem.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.AI;
@@ -26,6 +27,7 @@ using NotSupportedException = System.NotSupportedException;
 using PC = PixelCrushers.DialogueSystem;
 using SM = Sunshine.Metric;
 using Type = System.Type;
+using Task = Il2CppSystem.Threading.Tasks.Task;
 
 namespace DiscoAPI.Runtime
 {
@@ -370,6 +372,59 @@ namespace DiscoAPI.Runtime
 			return newArr.ToArray();
 		}
 	}
+
+	public static class AreaUtils
+	{
+		public static IAssetArena<Area> Areas => DiscoRunner.manager.Assets.GetArena<Area>();
+		public static bool IsModdedArea(string scenePath) => Areas.Any(a => a.scenePath == scenePath);
+		public static Area? FromScenePath(string scenePath) => Areas.FirstOrDefault(a => a.scenePath == scenePath);
+		public static Area? FromSceneName(string sceneName) => Areas.FirstOrDefault(a => a.scenePath.Contains(sceneName));
+
+		public static AsyncOperationHandle<AsyncOperation?> LoadModScene(Area area)
+		{
+			var sceneBundle = DiscoRunner.GetSource(area.source!)?.Router.SceneBundle.Get();
+			return AssetUtils.SpoofHandle<AsyncOperation>(complete => sceneBundle?.Task
+				.ContinueWith((Action<Task>)(task => LoadSceneCallback(task, area.scenePath)?
+				.add_completed((Action<AsyncOperation>)((op) => complete(op, null))))), sceneBundle);
+		}
+
+		private static AsyncOperation? LoadSceneCallback(Task handle, string scenePath)
+		{
+			var bundle = handle.Cast<Task<AssetBundle?>>().Result;
+			if (bundle == null)
+			{
+				DiscoRunner.Log.LogError($"a request to load scene bundle containing {scenePath} failed!");
+				return null;
+			}
+
+			var foundScenePath = bundle.GetAllScenePaths().FirstOrDefault(s => s == scenePath);
+			if (foundScenePath == null)
+			{
+				DiscoRunner.Log.LogError($"could not load {scenePath} from bundle {bundle.name}!");
+				return null;
+			}
+
+			return SceneManager.LoadSceneAsync(foundScenePath, LoadSceneMode.Additive);
+		}
+
+		public static AsyncOperationHandle<NavMeshData?> LoadNavmeshData(Area area)
+		{
+			var loadOp = DiscoRunner.GetSource(area.source!)?.Router.NavMeshes.Get(area.navMeshPath);
+			if (loadOp == null)
+			{
+				DiscoRunner.Log.LogError($"failed to load navmesh data at {area.navMeshPath} for source {area.source}");
+				return new AsyncOperationHandle<NavMeshData?>();
+			}
+			return loadOp;
+		}
+
+
+		public static void ChangeArea(string areaId, string destinationId, bool isGameLoad, bool showLoadingScreen,
+			bool hideLoadingScreen)
+		{
+			SingletonScriptable<ApplicationManager>.Singleton.ChangeArea(areaId, destinationId, isGameLoad, showLoadingScreen, hideLoadingScreen);
+		}
+	}
 }
 
 namespace System.Runtime.CompilerServices
@@ -382,43 +437,3 @@ namespace System.Runtime.CompilerServices
 		}
 	}
 }
-
-public static class AreaUtils
-{
-	const string sceneBundlePath = "BepInEx/plugins/dca/assetbundles/scenes";
-	const string navmeshBundlePath = "BepInEx/plugins/dca/assetbundles/navmeshes";
-	public static AssetBundle? sceneBundle;
-	public static AssetBundle? navmeshBundle;
-	public static IAssetArena<Area> Areas => DiscoRunner.manager.Assets.GetArena<Area>();
-	public static bool IsModdedArea(string scenePath) => Areas.Any(a => a.scenePath == scenePath);
-	public static Area? FromScenePath(string scenePath) => Areas.FirstOrDefault(a => a.scenePath == scenePath);
-	public static Area? FromSceneName(string sceneName) => Areas.FirstOrDefault(a => a.scenePath.Contains(sceneName));
-	
-	public static AsyncOperation? LoadModScene(Area area)
-	{
-		AreaUtils.sceneBundle ??= AssetBundle.LoadFromFile(sceneBundlePath);
-		var scenePath = AreaUtils.sceneBundle.GetAllScenePaths().FirstOrDefault(s => s == area.scenePath);
-
-		if (scenePath == null)
-		{
-			DiscoRunner.Log.LogError($"could not load {area.scenePath} from bundle {sceneBundlePath}!");
-			return null;
-		}
-		
-		return SceneManager.LoadSceneAsync(area.scenePath, LoadSceneMode.Additive);
-	}
-	
-	public static NavMeshData LoadNavmeshData(Area area)
-	{
-		AreaUtils.navmeshBundle ??= AssetBundle.LoadFromFile(navmeshBundlePath);
-		var mesh = AreaUtils.navmeshBundle.LoadAsset<NavMeshData>(area.navMeshPath);
-		return mesh;
-	}
-	
-	public static void ChangeArea(string areaId, string destinationId, bool isGameLoad, bool showLoadingScreen,
-		bool hideLoadingScreen)
-	{
-		SingletonScriptable<ApplicationManager>.Singleton.ChangeArea(areaId, destinationId, isGameLoad, showLoadingScreen, hideLoadingScreen);
-	}
-}
-

--- a/src/Runtime/Utils.cs
+++ b/src/Runtime/Utils.cs
@@ -239,7 +239,7 @@ namespace DiscoAPI.Runtime
 			return SpoofHandle<T>(execute, new());
 		}
 
-		public static AsyncOperationHandle<T?> SpoofHandle<T>(Action<Complete<T>> execute, AsyncOperationHandle dep)
+		public static AsyncOperationHandle<T?> SpoofHandle<T>(Action<Complete<T>> execute, AsyncOperationHandle dep) where T : Il2CppObjectBase
 		{
 			// please don't ask why this is like this.
 


### PR DESCRIPTION
- Defined Area assets which represent an explorable level
  - Requires paths to corresponding Scene and NavMesh assets
- Defined a `GenericArena<T>` which just wraps a `List<T>`
- Custom levels are automatically unloaded upon player exit
- Defined a `SceneBundleRoute`
  - We *can* make this implement `IAssetRoute`, but no other current `IAssetRoute` implementation is valid for scenes. It would also require `Get()` to have a string argument. In that case we could have the `Get()` method do the scene loading as well rather than leaving it to the caller.
- Created inherent routes for Scene and NavMesh bundles, mimicking implementation for portraits

Note that parts of this PR may be refactored as we reconsider how to package and represent all of the data required for a level. 

The `Utils.cs` file will need to be broken up at this point, I'm saving that for a separate commit.
