### PR TITLE
Feat: Extensible Reputation system

### DIFF
--- a/src/Common/Assets/Area.cs
+++ b/src/Common/Assets/Area.cs
@@ -37,3 +37,35 @@ public record Area : Asset, IAssetRef<Area>
     public new AssetLocation<Area> Location => new(source, id);
     Area? IAssetRef<Area>.Resolve(IDiscoManager mgr) => (Area?)((IAssetRef)this).Resolve(mgr);
 }
+
+public class Areas
+{
+    public static AssetLocation<Area> Whirling_int_f1 = new("Whirling-int-f1");
+    public static AssetLocation<Area> Whirling_int_f2 = new("Whirling-int-f2");
+    public static AssetLocation<Area> Whirling_int_f3 = new("Whirling-int-f3");
+    public static AssetLocation<Area> Whirling_int_f3_antechamber = new("Whirling-int-f3-antechamber");
+    public static AssetLocation<Area> Martinaise_ext = new("Martinaise-ext");
+    public static AssetLocation<Area> Doomed_commerce_int_f1 = new("Doomed-commerce-int-f1");
+    public static AssetLocation<Area> Doomed_commerce_int_f2 = new("Doomed-commerce-int-f2");
+    public static AssetLocation<Area> Doomed_commerce_int_s1 = new("Doomed-commerce-int-s1");
+    public static AssetLocation<Area> Capeside_coalchamber_int = new("Capeside-coalchamber-int");
+    public static AssetLocation<Area> Secretary_int = new("Secretary-int");
+    public static AssetLocation<Area> Pawnshop_int = new("Pawnshop-int");
+    public static AssetLocation<Area> Cunos_shack_int = new("Cunos-shack-int");
+    public static AssetLocation<Area> Capesider_smoker_int = new("Capeside-smoker-int");
+    public static AssetLocation<Area> Sea_fortress_int = new("Sea-fortress-int");
+    public static AssetLocation<Area> Tent_int = new("Tent-int");
+    public static AssetLocation<Area> Second_home_int = new("Second-home-int");
+    public static AssetLocation<Area> FV_house_int = new("FV-house-int");
+    public static AssetLocation<Area> Instigators_lair_int = new("Instigators-lair-int");
+    public static AssetLocation<Area> Union_container_int = new("Union-container-int");
+    public static AssetLocation<Area> Union_boss_int = new("Union-boss-int");
+    public static AssetLocation<Area> Capeside_wcw_int = new("Capeside-wcw-int");
+    public static AssetLocation<Area> Crypto_garys_apt_int = new("Crypto-garys-apt-int");
+    public static AssetLocation<Area> Dream_2 = new("Dream-2");
+    public static AssetLocation<Area> Dream_3_ext = new("Dream-3-ext");
+    public static AssetLocation<Area> Dream_3_int = new("Dream-3-int");
+    public static AssetLocation<Area> FV_shack_int = new("FV-shack-int");
+    public static AssetLocation<Area> Feld_int = new("Feld-int");
+    public static AssetLocation<Area> Commustudent_int = new("Commustudent-int");
+}

--- a/src/Common/Assets/Reputation.cs
+++ b/src/Common/Assets/Reputation.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace DiscoAPI.Common.Assets;
+
+public record Reputation : Asset, IAssetRef<Reputation>
+{
+    public readonly Action? repIncreaseEffect;
+    public readonly string? confrontationOrbName;
+    public readonly int? confrontationTriggerThreshold;
+    
+    public Reputation(string id, Action? repIncreaseEffect = null, 
+        int? confrontationTriggerThreshold = null, string? confrontationOrbName = null) : base(id)
+    {
+        this.repIncreaseEffect = repIncreaseEffect;
+        this.confrontationTriggerThreshold = confrontationTriggerThreshold;
+        this.confrontationOrbName = confrontationOrbName;
+    }
+    
+    public new AssetLocation<Reputation> Location => new(source, id);
+    Reputation? IAssetRef<Reputation>.Resolve(IDiscoManager mgr) => (Reputation?)((IAssetRef)this).Resolve(mgr);
+}

--- a/src/Runtime/InherentProvider.cs
+++ b/src/Runtime/InherentProvider.cs
@@ -41,6 +41,7 @@ public static class InherentProvider
 		assets.Register(new PCProxyArena<Task, PC.Conversation>(convos.Raw, (conv) => conv.FieldExists("display_condition_main")), false);
 		assets.Register(new GenericArena<Area>(), false);
 		assets.Register(new GenericArena<CharacterArchetype>(), false);
+		assets.Register(new EnumArena<Reputation, Common.Assets.Reputation>(ReputationUtils.RecoverRep, ReputationUtils.RepIsReal), true);
 
 		DiscoHooks.OnDialogueLoad += OnDialogueBundleLoad;
 
@@ -77,6 +78,8 @@ public static class InherentProvider
 
 	public static void OnDialogueBundleLoad()
 	{
+		ReputationUtils.RegisterModReputations();
+		
 		// we have to introduce a dummy actor with a simple portrait for the case where no skill is used in the portrait grid.
 		source.Add(new Actor("dummy-none-skill", DUMMY_NONE_SKILL) { portraitName = "portrait_none.png" });
 	}

--- a/src/Runtime/Patches/Archetypes.cs
+++ b/src/Runtime/Patches/Archetypes.cs
@@ -11,7 +11,7 @@ using SM = Sunshine.Metric;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class ArchetypePatches
+internal static class ArchetypePatches
 {
 
     [HarmonyPatch(typeof(ArchetypeSelectButton), nameof(ArchetypeSelectButton.SetArchetype))]

--- a/src/Runtime/Patches/Areas.cs
+++ b/src/Runtime/Patches/Areas.cs
@@ -11,7 +11,7 @@ using UnityEngine.SceneManagement;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class AreaPatches
+internal static class AreaPatches
 {
     [HarmonyPatch(typeof(ApplicationManager), nameof(ApplicationManager.ChangeArea))]
     [HarmonyPrefix]
@@ -120,36 +120,4 @@ public static class AreaPatches
         return false;
     }
 
-}
-
-public class Areas
-{
-    public static AssetLocation<Area> Whirling_int_f1 = new("Whirling-int-f1");
-    public static AssetLocation<Area> Whirling_int_f2 = new("Whirling-int-f2");
-    public static AssetLocation<Area> Whirling_int_f3 = new("Whirling-int-f3");
-    public static AssetLocation<Area> Whirling_int_f3_antechamber = new("Whirling-int-f3-antechamber");
-    public static AssetLocation<Area> Martinaise_ext = new("Martinaise-ext");
-    public static AssetLocation<Area> Doomed_commerce_int_f1 = new("Doomed-commerce-int-f1");
-    public static AssetLocation<Area> Doomed_commerce_int_f2 = new("Doomed-commerce-int-f2");
-    public static AssetLocation<Area> Doomed_commerce_int_s1 = new("Doomed-commerce-int-s1");
-    public static AssetLocation<Area> Capeside_coalchamber_int = new("Capeside-coalchamber-int");
-    public static AssetLocation<Area> Secretary_int = new("Secretary-int");
-    public static AssetLocation<Area> Pawnshop_int = new("Pawnshop-int");
-    public static AssetLocation<Area> Cunos_shack_int = new("Cunos-shack-int");
-    public static AssetLocation<Area> Capesider_smoker_int = new("Capeside-smoker-int");
-    public static AssetLocation<Area> Sea_fortress_int = new("Sea-fortress-int");
-    public static AssetLocation<Area> Tent_int = new("Tent-int");
-    public static AssetLocation<Area> Second_home_int = new("Second-home-int");
-    public static AssetLocation<Area> FV_house_int = new("FV-house-int");
-    public static AssetLocation<Area> Instigators_lair_int = new("Instigators-lair-int");
-    public static AssetLocation<Area> Union_container_int = new("Union-container-int");
-    public static AssetLocation<Area> Union_boss_int = new("Union-boss-int");
-    public static AssetLocation<Area> Capeside_wcw_int = new("Capeside-wcw-int");
-    public static AssetLocation<Area> Crypto_garys_apt_int = new("Crypto-garys-apt-int");
-    public static AssetLocation<Area> Dream_2 = new("Dream-2");
-    public static AssetLocation<Area> Dream_3_ext = new("Dream-3-ext");
-    public static AssetLocation<Area> Dream_3_int = new("Dream-3-int");
-    public static AssetLocation<Area> FV_shack_int = new("FV-shack-int");
-    public static AssetLocation<Area> Feld_int = new("Feld-int");
-    public static AssetLocation<Area> Commustudent_int = new("Commustudent-int");
 }

--- a/src/Runtime/Patches/Character.cs
+++ b/src/Runtime/Patches/Character.cs
@@ -12,7 +12,7 @@ using Il2CppSystem.Collections.Generic;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class CharacterPatches
+internal static class CharacterPatches
 {
 	[HarmonyPatch(typeof(SM.CharacterSheet), nameof(SM.CharacterSheet.Recalc))]
 	[HarmonyPostfix]

--- a/src/Runtime/Patches/Dialogue.cs
+++ b/src/Runtime/Patches/Dialogue.cs
@@ -3,7 +3,7 @@ using PC = PixelCrushers.DialogueSystem;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class DialoguePatches
+internal static class DialoguePatches
 {
     // DE uses the "Articy Id" for asset referencing (probably because PixelCrushers' asset identification systems are *awful*).
     // Since these are strings, we can trivially spoof out own "Articy Id" in whatever format we like.

--- a/src/Runtime/Patches/Managed.cs
+++ b/src/Runtime/Patches/Managed.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class ManagedPatches
+internal static class ManagedPatches
 {
 	private static ManualLogSource mockUnityLogger = BepInEx.Logging.Logger.CreateLogSource("Unity");
 

--- a/src/Runtime/Patches/Misc.cs
+++ b/src/Runtime/Patches/Misc.cs
@@ -4,7 +4,7 @@ using HarmonyLib;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class MiscPatches
+internal static class MiscPatches
 {
 	// its good etiquette to not let people cheese too easily.
 	// we're definitely double-counting some functions but inlining screws us in some places:

--- a/src/Runtime/Patches/MoraleHealth.cs
+++ b/src/Runtime/Patches/MoraleHealth.cs
@@ -6,7 +6,7 @@ using DiscoAPI.Runtime.Components;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class MoraleHealthPatches
+internal static class MoraleHealthPatches
 {
 	private static ModEntity<SM.CharacterSheet> You = DiscoRunner.world!.You();
 	private static SkillContainer YouSkills = CharacterComponents.Skills.Of(You)!;

--- a/src/Runtime/Patches/NewGame.cs
+++ b/src/Runtime/Patches/NewGame.cs
@@ -10,7 +10,7 @@ using Sunshine.Views;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class NewGamePatches
+internal static class NewGamePatches
 {
     [HarmonyPatch(typeof(WhirlingNewGameManager), nameof(WhirlingNewGameManager.RedButtonPressed))]
     [HarmonyPrefix]

--- a/src/Runtime/Patches/Pages.cs
+++ b/src/Runtime/Patches/Pages.cs
@@ -10,7 +10,7 @@ using LocalizationCustomSystem;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class PagesPatches
+internal static class PagesPatches
 {
 	[HarmonyPatch(typeof(ActorsPortraitsBundleManager), nameof(ActorsPortraitsBundleManager.LoadPortraitSpriteAsync))]
 	[HarmonyPrefix]

--- a/src/Runtime/Patches/Persistence.cs
+++ b/src/Runtime/Patches/Persistence.cs
@@ -2,7 +2,7 @@ using HarmonyLib;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public static class PersistencePatches
+internal static class PersistencePatches
 {
     [HarmonyPatch(typeof(SunshinePersistenceFileManager), nameof(SunshinePersistenceFileManager.PutDateSuffixOnPath))]
     [HarmonyPostfix] // alternative method patched due to inlined SaveCoR, triggers before basegame serialization

--- a/src/Runtime/Patches/Reputation.cs
+++ b/src/Runtime/Patches/Reputation.cs
@@ -1,0 +1,35 @@
+using System.Linq;
+using DiscoAPI.Runtime.Utils;
+using HarmonyLib;
+
+namespace DiscoAPI.Runtime.Patches;
+
+internal static class ReputationPatches
+{
+    [HarmonyPatch(typeof(ReputationAlterant), nameof(ReputationAlterant.ReputationEffect))]
+    [HarmonyPrefix]
+    private static bool OnReputationEffect(Reputation rep)
+    {
+        var modRep = DiscoRunner.manager.Assets.GetArena<Common.Assets.Reputation>()[(int)rep];
+        if (modRep == null || modRep.ResolveId() < ReputationUtils.VANILLA_REP_DIALOGUE_COUNT) return true;
+        
+        modRep.repIncreaseEffect?.Invoke();
+        return false;
+    }
+
+    [HarmonyPatch(typeof(ReputationAlterant), nameof(ReputationAlterant.ModifyIfDifferentFromZero))]
+    [HarmonyPrefix]
+    private static bool OnModifyReputation(string reputationName, int value)
+    {
+        var modRep = DiscoRunner.manager.Assets.GetArena<Common.Assets.Reputation>().FirstOrDefault(r => r.id == reputationName);
+        
+        ReputationAlterant.ModifyReputation(reputationName, value);
+        if (modRep != null)
+        {
+            var repEnum = (Reputation)modRep.ResolveId(); 
+            ReputationAlterant.ReputationEffect(repEnum);
+            ReputationAlterant.ObsessionGiver(repEnum);
+        }
+        return false;
+    }
+}

--- a/src/Runtime/Patches/Reputation.cs
+++ b/src/Runtime/Patches/Reputation.cs
@@ -11,7 +11,7 @@ internal static class ReputationPatches
     private static bool OnReputationEffect(Reputation rep)
     {
         var modRep = DiscoRunner.manager.Assets.GetArena<Common.Assets.Reputation>()[(int)rep];
-        if (modRep == null || modRep.ResolveId() < ReputationUtils.VANILLA_REP_DIALOGUE_COUNT) return true;
+        if (modRep == null || (int)rep < ReputationUtils.VANILLA_REP_DIALOGUE_COUNT) return true;
         
         modRep.repIncreaseEffect?.Invoke();
         return false;

--- a/src/Runtime/Patches/VirtualTexture.cs
+++ b/src/Runtime/Patches/VirtualTexture.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace DiscoAPI.Runtime.Patches;
 
-public class VirtualTexturePatches
+internal class VirtualTexturePatches
 {
 	private record NativeDecompressor(IntPtr nativeHandle) : IBcnDecompressor
 	{

--- a/src/Runtime/Plugin.cs
+++ b/src/Runtime/Plugin.cs
@@ -52,6 +52,7 @@ public class DiscoAPIPlugin : BasePlugin
         PatchAll(typeof(Patches.AreaPatches));
         PatchAll(typeof(Patches.VirtualTexturePatches));
         PatchAll(typeof(Patches.NewGamePatches));
+        PatchAll(typeof(Patches.ReputationPatches));
         DialogueBundleLoader.bundleWasLoaded.AddListener((Action)DiscoRunner.OnDialogueBundleLoad);
 
         DiscoRunner.OnLoad();

--- a/src/Runtime/Utils/Assets.cs
+++ b/src/Runtime/Utils/Assets.cs
@@ -85,8 +85,11 @@ internal static class ReputationUtils
             var modRep = repArena[i];
             confrontDialogues[i] = modRep?.confrontationOrbName ?? "";
             thoughtCache[i] = modRep?.id ?? "";
-            ReputationAlterant.reputationSystemIndividualLevels.TryAdd((Reputation)modRep.ResolveId(),
-                modRep.confrontationTriggerThreshold ?? 999);
+            if (modRep?.confrontationTriggerThreshold != null)
+            {
+                ReputationAlterant.reputationSystemIndividualLevels.TryAdd((Reputation)modRep.ResolveId(),
+                    modRep.confrontationTriggerThreshold.Value);
+            }
         }
 
         ReputationAlterant.orbDialogues = confrontDialogues;

--- a/src/Runtime/Utils/Assets.cs
+++ b/src/Runtime/Utils/Assets.cs
@@ -50,3 +50,37 @@ public static class AssetUtils
         throw new Exception("failed to load even fallback portrait");
     }
 }
+
+internal static class ReputationUtils
+{
+    public const int VANILLA_REP_DIALOGUE_COUNT = 15;
+
+    public static bool RepIsReal(Reputation rep) => true;
+
+    public static Common.Assets.Reputation RecoverRep(Reputation smRep)
+    {
+        bool repHasLevel = ReputationAlterant.reputationSystemIndividualLevels.TryGetValue(smRep, out int repLevel);
+        return new Common.Assets.Reputation(
+            smRep.ToString(), null, 
+            repHasLevel ? repLevel : null, 
+            ReputationAlterant.orbDialogues[(int)smRep]);
+    }
+    
+    public static void RegisterModReputations()
+    {
+        var repArena = DiscoRunner.manager.Assets.GetArena<Common.Assets.Reputation>();
+        int repArenaLength = repArena.Count;
+        var confrontDialogues =
+            ReputationAlterant.orbDialogues.Resize(ReputationAlterant.orbDialogues.Length + repArenaLength);
+
+        for (int i = VANILLA_REP_DIALOGUE_COUNT; i < repArenaLength; i++)
+        {
+            var modRep = repArena[i];
+            confrontDialogues[i] = modRep?.confrontationOrbName ?? "";
+            ReputationAlterant.reputationSystemIndividualLevels.TryAdd((Reputation)modRep.ResolveId(),
+                modRep.confrontationTriggerThreshold ?? 999);
+        }
+
+        ReputationAlterant.orbDialogues = confrontDialogues;
+    }
+}

--- a/src/Runtime/Utils/Assets.cs
+++ b/src/Runtime/Utils/Assets.cs
@@ -72,15 +72,19 @@ internal static class ReputationUtils
         int repArenaLength = repArena.Count;
         var confrontDialogues =
             ReputationAlterant.orbDialogues.Resize(ReputationAlterant.orbDialogues.Length + repArenaLength);
+        var thoughtCache =
+            ReputationAlterant.copotypeThought.Resize(ReputationAlterant.orbDialogues.Length + repArenaLength);
 
         for (int i = VANILLA_REP_DIALOGUE_COUNT; i < repArenaLength; i++)
         {
             var modRep = repArena[i];
             confrontDialogues[i] = modRep?.confrontationOrbName ?? "";
+            thoughtCache[i] = modRep?.id ?? "";
             ReputationAlterant.reputationSystemIndividualLevels.TryAdd((Reputation)modRep.ResolveId(),
                 modRep.confrontationTriggerThreshold ?? 999);
         }
 
         ReputationAlterant.orbDialogues = confrontDialogues;
+        ReputationAlterant.copotypeThought = thoughtCache;
     }
 }

--- a/src/Runtime/Utils/Misc.cs
+++ b/src/Runtime/Utils/Misc.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading;
 using DiscoAPI.Common.Assets;
@@ -145,6 +146,24 @@ namespace DiscoAPI.Runtime
 		{
 			// i am trusting that this does not leak 'original'
 			var newArr = new T[newSize];
+			if (newSize >= original.Length)
+			{
+				original.CopyTo(newArr, 0);
+			}
+			else
+			{
+				for (int i = 0; i < newArr.Length; i++)
+				{
+					newArr[i] = original[i];
+				}
+			}
+
+			return newArr;
+		}
+		
+		public static Il2CppStringArray Resize(this Il2CppStringArray original, int newSize) 
+		{
+			var newArr = new string[newSize];
 			if (newSize >= original.Length)
 			{
 				original.CopyTo(newArr, 0);


### PR DESCRIPTION
Lets modders include their own affiliation that can be tracked. Modders can optionally provide an action to trigger when reputation is increased and/or an orb to show above a certain threshold.

There is a matching branch over in DCA (feat/reputation) with ours implemented.

Question: Is "Reputation" or "Affiliation" a better name for the Asset? Or something else?